### PR TITLE
Fix CI test and documentation pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,8 @@ jobs:
         python -m pip install black==24.10.0 isort==5.13.2
     - name: Run format checks
       run: |
-        PY_FILES="$(git ls-files '*.py')"
-        black --check --diff $PY_FILES
-        isort --check-only --diff $PY_FILES
+        git ls-files -z '*.py' | xargs -0 black --check --diff
+        git ls-files -z '*.py' | xargs -0 isort --check-only --diff
   lint:
     name: Lint (pylint+mypy)
     runs-on: ubuntu-latest
@@ -36,69 +35,90 @@ jobs:
     - name: Install lint tools
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pylint mypy
+        python -m pip install pylint==4.0.6 mypy==2.3.0
     - name: Lint
       run: |
-        pylint justatom --errors-only --disable=import-error
-        mypy justatom --ignore-missing-imports
+        pylint justatom --errors-only --disable=import-error,not-callable
+        mypy \
+          justatom/training/config.py \
+          justatom/training/methods.py \
+          justatom/training/alpha_gate.py \
+          justatom/training/memory_bank.py \
+          justatom/training/objective.py \
+          justatom/training/sampling.py \
+          justatom/training/telemetry.py \
+          justatom/training/module.py \
+          justatom/training/data.py \
+          justatom/training/job.py \
+          --ignore-missing-imports \
+          --follow-imports=skip
   pytest-ubuntu:
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
-    name: Tests (Ubuntu)
+        python-version: [ '3.10', '3.11', '3.12' ]
+    name: Tests (Ubuntu, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
     - name: Install requirements
-      run: pip install .[torch,test]
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[torch,test]"
     - name: Run tests
-      run: RUN_SLOW_TESTS=1 pytest tests -m "not integration"
+      env:
+        RUN_SLOW_TESTS: '1'
+      run: python -m pytest tests -m "not integration"
   pytest-windows:
     name: Tests (Windows)
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-        architecture: 'x64'
     - name: Install requirements
-      run: pip install .[torch,test]
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[torch,test]"
     - name: Run tests
-      run: pytest tests -m "not integration"
+      run: python -m pytest tests -m "not integration"
   pytest-macos:
     name: Tests (MacOS)
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        architecture: 'x64'
     - name: Install requirements
-      run: pip install .[torch,test]
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[torch,test]"
     - name: Run tests
-      run: RUN_SLOW_TESTS=1 pytest tests -m "not integration"
+      env:
+        RUN_SLOW_TESTS: '1'
+      run: python -m pytest tests -m "not integration"
 
   pytest-integration-weaviate:
     name: Integration tests (Weaviate, Ubuntu)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        architecture: 'x64'
     - name: Start Weaviate
       run: docker compose up -d weaviate
     - name: Install requirements
-      run: pip install .[torch,test]
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[torch,test]"
     - name: Run integration tests
-      run: pytest tests -m integration
+      run: python -m pytest tests -m integration
   build-docs:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,9 +69,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install ".[torch,test]"
     - name: Run tests
-      env:
-        RUN_SLOW_TESTS: '1'
-      run: python -m pytest tests -m "not integration"
+      run: python -m pytest tests -m "not integration and not network"
   pytest-windows:
     name: Tests (Windows)
     runs-on: windows-latest
@@ -85,7 +83,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install ".[torch,test]"
     - name: Run tests
-      run: python -m pytest tests -m "not integration"
+      run: python -m pytest tests -m "not integration and not network"
   pytest-macos:
     name: Tests (MacOS)
     runs-on: macos-latest
@@ -103,9 +101,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install ".[torch,test]"
     - name: Run tests
-      env:
-        RUN_SLOW_TESTS: '1'
-      run: python -m pytest tests -m "not integration"
+      run: python -m pytest tests -m "not integration and not network"
 
   pytest-integration-weaviate:
     name: Integration tests (Weaviate, Ubuntu)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,10 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+    - name: Install supported Bash
+      run: |
+        brew install bash
+        echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
     - name: Install requirements
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -4,13 +4,12 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+
 jobs:
   deploy-docs:
     name: Deploy documentation
     uses: ./.github/workflows/docs-reusable.yaml
     with:
       deploy: true
-      external-repository: justatom/cayleypy-docs
-      publish-branch: gh-pages
-    secrets:
-      docs-deploy-key: ${{ secrets.DOCS_DEPLOY_KEY }}

--- a/.github/workflows/docs-reusable.yaml
+++ b/.github/workflows/docs-reusable.yaml
@@ -13,20 +13,6 @@ on:
         required: false
         type: boolean
         default: false
-      external-repository:
-        description: Target repository for GitHub Pages publish
-        required: false
-        type: string
-        default: ''
-      publish-branch:
-        description: Target branch for GitHub Pages publish
-        required: false
-        type: string
-        default: 'gh-pages'
-    secrets:
-      docs-deploy-key:
-        description: Deploy key for pushing docs to external repository
-        required: false
 
 jobs:
   docs:
@@ -41,16 +27,12 @@ jobs:
     - name: Install docs dependencies
       run: |
         python -m pip install --upgrade pip
-        sudo apt-get update
-        sudo apt-get install -y pandoc
-        python -m pip install -r docs/requirements.txt
+        python -m pip install -r requirements-docs.txt
     - name: Build docs
-      run: bash docs/build_docs.sh
+      run: python -m mkdocs build --strict
     - name: Push documentation to GitHub Pages
-      if: ${{ inputs.deploy && inputs.external-repository != '' }}
-      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ inputs.deploy }}
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        publish_dir: ./docs/_build/html
-        external_repository: ${{ inputs.external-repository }}
-        publish_branch: ${{ inputs.publish-branch }}
-        deploy_key: ${{ secrets.docs-deploy-key }}
+        github_token: ${{ github.token }}
+        publish_dir: ./site

--- a/justatom/api/__init__.py
+++ b/justatom/api/__init__.py
@@ -1,3 +1,3 @@
-from justatom.running.llm import OpenAiTask, OpenAIAsyncWrapper
+from justatom.running.llm import OpenAIAsyncWrapper, OpenAiTask
 
 __all__ = ["OpenAiTask", "OpenAIAsyncWrapper"]

--- a/justatom/api/datasets.py
+++ b/justatom/api/datasets.py
@@ -18,7 +18,6 @@ from justatom.configuring.scenarios import deep_merge, load_scenario_config, par
 from justatom.running.llm import OpenAIAsyncWrapper, OpenAiTask
 from justatom.storing.dataset import API as DatasetApi
 
-
 _TEMPLATE_RE = re.compile(r"\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}")
 
 

--- a/justatom/api/eval.py
+++ b/justatom/api/eval.py
@@ -12,15 +12,13 @@ import polars as pl
 from loguru import logger
 from tqdm.auto import tqdm
 
-from justatom.configuring.scenarios import deep_merge
-from justatom.configuring.scenarios import load_scenario_config
-from justatom.configuring.scenarios import parse_unknown_overrides
+from justatom.configuring.scenarios import deep_merge, load_scenario_config, parse_unknown_overrides
 from justatom.running.evaluator import EvaluatorRunner
 from justatom.running.mask import IEvaluatorRunner
 from justatom.running.service import RunningService
+from justatom.tooling import stl
 from justatom.tooling.collections import resolve_collection_name, resolve_collection_tag
 from justatom.tooling.dataset import DatasetRecordAdapter
-from justatom.tooling import stl
 
 dotenv.load_dotenv()
 

--- a/justatom/api/train.py
+++ b/justatom/api/train.py
@@ -5,11 +5,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from justatom.configuring.scenarios import (
-    deep_merge,
-    load_scenario_config,
-    parse_unknown_overrides,
-)
+from justatom.configuring.scenarios import deep_merge, load_scenario_config, parse_unknown_overrides
 from justatom.training.config import TrainConfig, TrainingMethod, parse_train_config
 from justatom.training.job import TrainingJob, TrainingResult
 

--- a/justatom/configuring/__init__.py
+++ b/justatom/configuring/__init__.py
@@ -1,5 +1,4 @@
 from justatom.configuring.prime import Config
 from justatom.configuring.scenarios import load_scenario_config
 
-
 __all__ = ["Config", "load_scenario_config"]

--- a/justatom/configuring/builtins.py
+++ b/justatom/configuring/builtins.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import yaml
 
-
 _ENV_VAR_RE = re.compile(r"\$\{([A-Z0-9_]+)\}")
 _BUILTIN_URI_PREFIX = "builtin://"
 

--- a/justatom/modeling/numeric.py
+++ b/justatom/modeling/numeric.py
@@ -20,23 +20,17 @@ class NUMGenerator:
                 yield gamma_fn(xi)
 
     def beta(self, x: float | list[float], y: float | list[float]) -> Generator:
-        assert type(x) is type(
-            y
-        ), f"Data types do not match between {type(x)} != {type(y)}."
+        assert type(x) is type(y), f"Data types do not match between {type(x)} != {type(y)}."
         if isinstance(x, (int, float)):  # noqa: UP038
             yield gamma_fn(x) * gamma_fn(y) / gamma_fn(x + y)
         elif isinstance(x, list):
             for xi, yi in zip(x, y, strict=False):
                 yield gamma_fn(xi) * gamma_fn(yi) / gamma_fn(xi + yi)
         else:
-            raise ValueError(
-                f"Data types match {type(x)} == {type(y)} but not allowed. Use <float> or <List[float]>"
-            )
+            raise ValueError(f"Data types match {type(x)} == {type(y)} but not allowed. Use <float> or <List[float]>")
 
     def volume(self, eps: float, r: float, shape: str = "sphere") -> Generator:
-        assert (
-            shape in self.SHAPES
-        ), f"Provided shape={shape} is not one of {','.join(self.SHAPES)}"
+        assert shape in self.SHAPES, f"Provided shape={shape} is not one of {','.join(self.SHAPES)}"
         # TODO:
         return 1
 

--- a/justatom/processing/loader.py
+++ b/justatom/processing/loader.py
@@ -55,9 +55,7 @@ class NamedDataLoader(DataLoader):
                     f" supplied: {_tensor_names}"
                 )
 
-            max_num_labels = self._compute_max_number_of_labels(
-                batch=batch, tensor_names=_tensor_names
-            )
+            max_num_labels = self._compute_max_number_of_labels(batch=batch, tensor_names=_tensor_names)
 
             ret = {name: [] for name in _tensor_names}
             for example in batch:

--- a/justatom/processing/silo.py
+++ b/justatom/processing/silo.py
@@ -13,9 +13,7 @@ def get_dict_checksum(payload_dict):
     """
     Get MD5 checksum for a dict.
     """
-    checksum = hashlib.md5(
-        json.dumps(payload_dict, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    checksum = hashlib.md5(json.dumps(payload_dict, sort_keys=True).encode("utf-8")).hexdigest()
     return checksum
 
 
@@ -42,18 +40,14 @@ class _StreamingDataSet(IterableDataset):
 
     def __len__(self):
         if self._num_samples is None:
-            raise TypeError(
-                "Streaming dataset length is unknown for this iterable source"
-            )
+            raise TypeError("Streaming dataset length is unknown for this iterable source")
         return self._num_samples
 
     def _iter_source(self):
         if self.shuffle:
             if isinstance(self.dicts, list):
                 return iter(random.sample(self.dicts, len(self.dicts)))
-            logger.warning(
-                "shuffle=True is ignored for streaming datasets without random access."
-            )
+            logger.warning("shuffle=True is ignored for streaming datasets without random access.")
         return iter(self.dicts)
 
     def _iter_worker_shard(self):
@@ -70,11 +64,9 @@ class _StreamingDataSet(IterableDataset):
                 yield row
 
     def _emit_processed_batch(self, processing_batch: list[dict]):
-        dataset, tensor_names, problematic_sample_ids = (
-            self.processor.dataset_from_dicts(
-                dicts=processing_batch,
-                indices=list(range(len(processing_batch))),
-            )
+        dataset, tensor_names, problematic_sample_ids = self.processor.dataset_from_dicts(
+            dicts=processing_batch,
+            indices=list(range(len(processing_batch))),
         )
         if tensor_names is not None:
             self.tensor_names = tensor_names
@@ -120,9 +112,7 @@ def igniset(
     num_dicts = len(dicts)
     problems = set()
     dicts = random.sample(dicts, len(dicts)) if shuffle else dicts
-    for i in tqdm(
-        range(0, num_dicts, batch_size), desc="Preprocessing dataset", unit=" Dicts"
-    ):
+    for i in tqdm(range(0, num_dicts, batch_size), desc="Preprocessing dataset", unit=" Dicts"):
         processing_batch = dicts[i : i + batch_size]
         dataset, tensor_names, problematic_sample_ids = processor.dataset_from_dicts(
             dicts=processing_batch,

--- a/justatom/running/clusters.py
+++ b/justatom/running/clusters.py
@@ -53,17 +53,13 @@ class DocEmbedder(IDocEmbedder):
             streaming=streaming_preprocessing,
         )
 
-        loader = NamedDataLoader(
-            dataset=dataset, batch_size=batch_size, tensor_names=tensor_names
-        )
+        loader = NamedDataLoader(dataset=dataset, batch_size=batch_size, tensor_names=tensor_names)
 
         batch_gen = range(0, len(texts), batch_size)
         if verbose:
             batch_gen = tqdm(batch_gen)
 
-        for batch_begin, batch_features in zip(
-            batch_gen, loader, strict=False
-        ):  # noqa: B007
+        for batch_begin, batch_features in zip(batch_gen, loader, strict=False):  # noqa: B007
             batch = {k: v.to(self.device) for k, v in batch_features.items()}
 
             embeddings = model(**batch)[0].cpu()
@@ -89,9 +85,7 @@ class IHFWrapperBackend(BaseEmbedder):
             Document/words embeddings with shape (n, m) with `n` documents/words
             that each have an embeddings size of `m`
         """
-        embeddings = list(
-            self.model.encode(documents, batch_size=self.batch_size, verbose=verbose)
-        )
+        embeddings = list(self.model.encode(documents, batch_size=self.batch_size, verbose=verbose))
         embeddings = np.vstack(embeddings)
         return embeddings
 
@@ -128,9 +122,7 @@ class IEmbeddingClientBackend(BaseEmbedder):
 
     def embed(self, documents: list[str], verbose: bool = False) -> np.ndarray:
         del verbose
-        vectors = self._run_async(
-            self.client.embed(texts=documents, **self.embed_props)
-        )
+        vectors = self._run_async(self.client.embed(texts=documents, **self.embed_props))
         if len(vectors) == 0:
             return np.empty((0, 0))
         return np.asarray(vectors, dtype=np.float32)
@@ -145,9 +137,7 @@ class IBTRunner(IClusteringRunner):
             kwargs["n_gram_range"] = tuple(kwargs["n_gram_range"])
         self.topic_model = BERTopic(embedding_model=model, **kwargs)
 
-    def fit_transform(
-        self, docs: list[str | Document], **kwargs
-    ) -> tuple[list[int], np.ndarray | None]:
+    def fit_transform(self, docs: list[str | Document], **kwargs) -> tuple[list[int], np.ndarray | None]:
         _docs = [str(d) if isinstance(d, str) else d.content for d in docs]
 
         topics, probs = self.topic_model.fit_transform(documents=_docs, **kwargs)

--- a/justatom/running/embeddings/__init__.py
+++ b/justatom/running/embeddings/__init__.py
@@ -1,8 +1,6 @@
 from justatom.running.embeddings.base import IEmbeddingClient
 from justatom.running.embeddings.local import LocalEmbeddingClient
-from justatom.running.embeddings.openai_compatible import (
-    OpenAICompatibleEmbeddingClient,
-)
+from justatom.running.embeddings.openai_compatible import OpenAICompatibleEmbeddingClient
 
 
 class EmbeddingClientFactory:

--- a/justatom/running/embeddings/local.py
+++ b/justatom/running/embeddings/local.py
@@ -5,9 +5,7 @@ import asyncio as asio
 import torch
 
 from justatom.modeling.mask import ILanguageModel
-from justatom.processing import RuntimeProcessor
-from justatom.processing import ITokenizer
-from justatom.processing import igniset
+from justatom.processing import ITokenizer, RuntimeProcessor, igniset
 from justatom.processing.loader import NamedDataLoader
 from justatom.running.embeddings.base import IEmbeddingClient
 from justatom.running.encoders import EncoderRunner

--- a/justatom/running/embeddings/openai_compatible.py
+++ b/justatom/running/embeddings/openai_compatible.py
@@ -35,9 +35,7 @@ class OpenAICompatibleEmbeddingClient(IEmbeddingClient):
         self.default_pooling = default_pooling
         self.default_encoding_format = default_encoding_format
         self.default_max_seq_len = (
-            int(default_max_seq_len)
-            if default_max_seq_len is not None and int(default_max_seq_len) > 0
-            else None
+            int(default_max_seq_len) if default_max_seq_len is not None and int(default_max_seq_len) > 0 else None
         )
 
     @staticmethod
@@ -90,11 +88,7 @@ class OpenAICompatibleEmbeddingClient(IEmbeddingClient):
 
         input_type = str(props.pop("input_type", self.default_input_type))
         apply_prefix = bool(props.pop("apply_prefix", self.prefix_enabled))
-        normalized = (
-            [self._apply_prefix(t, input_type) for t in texts]
-            if apply_prefix
-            else list(texts)
-        )
+        normalized = [self._apply_prefix(t, input_type) for t in texts] if apply_prefix else list(texts)
 
         payload = {
             "model": model or self.model,
@@ -110,9 +104,7 @@ class OpenAICompatibleEmbeddingClient(IEmbeddingClient):
         elif self.default_encoding_format:
             payload["encoding_format"] = self.default_encoding_format
 
-        payload_max_seq_len = self._normalize_optional_int(
-            props.pop("max_seq_len", self.default_max_seq_len)
-        )
+        payload_max_seq_len = self._normalize_optional_int(props.pop("max_seq_len", self.default_max_seq_len))
         if payload_max_seq_len is not None:
             payload["max_seq_len"] = payload_max_seq_len
 

--- a/justatom/running/encoders.py
+++ b/justatom/running/encoders.py
@@ -1,10 +1,10 @@
+import os
 from pathlib import Path
 
 import simplejson as json
 import torch
-import torch.nn.functional as F
 import torch.nn as nn
-import os
+import torch.nn.functional as F
 from loguru import logger
 
 from justatom.modeling.div import loss_per_head_sum

--- a/justatom/running/indexer.py
+++ b/justatom/running/indexer.py
@@ -1,6 +1,7 @@
 import asyncio as asio
-import torch
 from collections.abc import Iterable
+
+import torch
 from loguru import logger
 from more_itertools import chunked
 from tqdm.asyncio import tqdm_asyncio
@@ -10,7 +11,7 @@ from justatom.etc.schema import Document
 from justatom.processing import igniset
 from justatom.processing.loader import NamedDataLoader
 from justatom.processing.mask import IProcessor
-from justatom.running.encoders import EncoderRunner, BiEncoderRunner
+from justatom.running.encoders import BiEncoderRunner, EncoderRunner
 from justatom.running.mask import IIndexerRunner
 from justatom.storing.mask import INNDocStore
 
@@ -28,9 +29,7 @@ class NNIndexer(IIndexerRunner):
         self.processor = processor
         self.device = device
         if runner.device != device:
-            logger.info(
-                f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}"
-            )
+            logger.info(f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}")
         self.runner.to(device)
 
     def _runner(
@@ -50,9 +49,7 @@ class NNIndexer(IIndexerRunner):
             self.runner.to(device)
             self.runner = self.runner.eval()
         for i, docs_chunk in enumerate(chunked(documents, n=batch_size)):
-            documents_as_dicts = [
-                d.to_dict() if isinstance(d, Document) else d for d in docs_chunk
-            ]
+            documents_as_dicts = [d.to_dict() if isinstance(d, Document) else d for d in docs_chunk]
             if len(documents_as_dicts) == 0:
                 continue
 
@@ -68,9 +65,7 @@ class NNIndexer(IIndexerRunner):
                 batch_size=batch_size,
             )
 
-            for docs, batch in zip(
-                chunked(documents_as_dicts, n=batch_size), loader, strict=False
-            ):
+            for docs, batch in zip(chunked(documents_as_dicts, n=batch_size), loader, strict=False):
                 batches = {k: v.to(device) for k, v in batch.items()}
                 with torch.no_grad():
                     vectors = self.runner(batch=batches)[0].cpu().numpy()
@@ -125,9 +120,7 @@ class NNIndexer(IIndexerRunner):
         n_total_written_docs: int = 0
         pending: set[asio.Task] = set()
 
-        for batch_idx, docs_with_embeddings_batch in tqdm_asyncio(
-            enumerate(docs_with_embeddings)
-        ):
+        for batch_idx, docs_with_embeddings_batch in tqdm_asyncio(enumerate(docs_with_embeddings)):
             pending.add(
                 asio.create_task(
                     self._write_batch(
@@ -169,14 +162,7 @@ class KWARGIndexer(IIndexerRunner):
         for batch_idx, docs_batch in enumerate(chunked(documents, n=batch_size)):
             try:
                 cur_written_docs = await self.store.write_documents(
-                    [
-                        (
-                            Document(content=doc)
-                            if isinstance(doc, str)
-                            else Document.from_dict(doc)
-                        )
-                        for doc in docs_batch
-                    ],
+                    [(Document(content=doc) if isinstance(doc, str) else Document.from_dict(doc)) for doc in docs_batch],
                     batch_size=batch_size_per_request,
                 )
             except DocumentStoreError as error:
@@ -200,10 +186,7 @@ class ByName:
         elif name in ["embedding", "hybrid", "gamma-hybrid"]:
             klass = NNIndexer
         else:
-            msg = (
-                f"Unknown name=[{name}] to init IIndexerRunner instance. "
-                f"Use one of {', '.join(self.OPS)}"
-            )
+            msg = f"Unknown name=[{name}] to init IIndexerRunner instance. " f"Use one of {', '.join(self.OPS)}"
             logger.error(msg)
             raise ValueError(msg)
 

--- a/justatom/running/mask.py
+++ b/justatom/running/mask.py
@@ -6,10 +6,22 @@ from typing import Any
 
 import numpy as np
 import simplejson as json
-from bertopic.backend import BaseEmbedder
 from loguru import logger
-from justatom.modeling.mask import ILanguageModel
+
+try:
+    from bertopic.backend import BaseEmbedder
+except ModuleNotFoundError:
+
+    class BaseEmbedder:
+        """Compatibility base used when the optional clustering extra is absent."""
+
+        def __init__(self, embedding_model=None, word_embedding_model=None):
+            self.embedding_model = embedding_model
+            self.word_embedding_model = word_embedding_model
+
+
 from justatom.etc.schema import Document
+from justatom.modeling.mask import ILanguageModel
 
 
 class IModelRunner:

--- a/justatom/running/retriever.py
+++ b/justatom/running/retriever.py
@@ -9,8 +9,8 @@ from more_itertools import chunked
 from justatom.processing.loader import NamedDataLoader
 from justatom.processing.mask import IProcessor
 from justatom.processing.silo import igniset
-from justatom.running.encoders import EncoderRunner, BiEncoderRunner
-from justatom.running.mask import IRetrieverRunner, IModelRunner
+from justatom.running.encoders import BiEncoderRunner, EncoderRunner
+from justatom.running.mask import IModelRunner, IRetrieverRunner
 from justatom.storing.mask import INNDocStore
 from justatom.tooling.nlp import keywords_metrics
 
@@ -36,9 +36,7 @@ def _coerce_results_per_query(results, n_queries: int):
             "Please ensure backend store returns per-query grouped results."
         )
     if len(results) != n_queries:
-        raise ValueError(
-            f"Retriever expected {n_queries} per-query result groups, got {len(results)}."
-        )
+        raise ValueError(f"Retriever expected {n_queries} per-query result groups, got {len(results)}.")
     return results
 
 
@@ -72,9 +70,7 @@ class GammaHybridRetriever(IRetrieverRunner):
         self.processor = processor
         self.device = device
         if runner.device != device:
-            logger.info(
-                f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}"
-            )
+            logger.info(f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}")
             runner.to(device)  # type: ignore
         self.runner = runner.eval()  # type: ignore
         if ranker not in self.RANKER:
@@ -140,17 +136,9 @@ class GammaHybridRetriever(IRetrieverRunner):
         cutoff_score = self.cutoff_score if cutoff_score is None else cutoff_score
         gamma1 = self.gamma1 if gamma1 is None else gamma1
         gamma2 = self.gamma2 if gamma2 is None else gamma2
-        include_keywords = (
-            self.include_keywords if include_keywords is None else include_keywords
-        )
-        include_explanation = (
-            self.include_explanation
-            if include_explanation is None
-            else include_explanation
-        )
-        include_content = (
-            self.include_content if include_content is None else include_content
-        )
+        include_keywords = self.include_keywords if include_keywords is None else include_keywords
+        include_explanation = self.include_explanation if include_explanation is None else include_explanation
+        include_content = self.include_content if include_content is None else include_content
         if not include_keywords and not include_explanation and not include_content:
             msg = f"""
             You've initialized `{self.__class__.__name__}` IR but not using any of the atomic keywords features.
@@ -167,33 +155,20 @@ class GammaHybridRetriever(IRetrieverRunner):
             raise ValueError(msg)
         single_query = isinstance(queries, str)
         queries = [queries] if single_query else queries
-        js_queries = [
-            (
-                {"content": q}
-                if prefix is None
-                else {"content": q, "meta": {"prefix": prefix}}
-            )
-            for q in queries
-        ]
+        js_queries = [({"content": q} if prefix is None else {"content": q, "meta": {"prefix": prefix}}) for q in queries]
         dataset, tensor_names = igniset(
             js_queries,
             processor=self.processor,
             batch_size=batch_size,
             streaming=streaming_preprocessing,
         )
-        loader = NamedDataLoader(
-            dataset, tensor_names=tensor_names, batch_size=batch_size
-        )
+        loader = NamedDataLoader(dataset, tensor_names=tensor_names, batch_size=batch_size)
         answer = []
 
-        for _queries, _batches in zip(
-            chunked(queries, n=batch_size), loader, strict=False
-        ):
+        for _queries, _batches in zip(chunked(queries, n=batch_size), loader, strict=False):
             batches = {k: v.to(self.device) for k, v in _batches.items()}
             with torch.no_grad():
-                vectors = (
-                    self.runner(batch=batches)[0].cpu().numpy().tolist()
-                )  # batch_size x vector_dim
+                vectors = self.runner(batch=batches)[0].cpu().numpy().tolist()  # batch_size x vector_dim
             answer_per_batch_topp = await self.store.search(
                 queries=_queries,
                 queries_embeddings=vectors,
@@ -221,21 +196,14 @@ class GammaHybridRetriever(IRetrieverRunner):
                     keywords_content: str = [doc.content] if include_content else []  # type: ignore
                     if include_keywords and include_explanation:
                         keywords_content += [
-                            kwp["keyword_or_phrase"].strip()
-                            + " "
-                            + kwp["explanation"].strip()
-                            for kwp in keywords_or_phrases
+                            kwp["keyword_or_phrase"].strip() + " " + kwp["explanation"].strip() for kwp in keywords_or_phrases
                         ]  # type: ignore
                     elif include_keywords:
                         keywords_content += [kwp["keyword_or_phrase"].strip() for kwp in keywords_or_phrases]  # type: ignore
                     else:
                         keywords_content += [kwp["explanation"].strip() for kwp in keywords_or_phrases]  # type: ignore
-                        keywords_content += "\n".join(
-                            [kwp["explanation"].strip() for kwp in keywords_or_phrases]
-                        )
-                    keyword_score: float = self.ranker(
-                        query, keywords_content, score_cutoff=cutoff_score
-                    )
+                        keywords_content += "\n".join([kwp["explanation"].strip() for kwp in keywords_or_phrases])
+                    keyword_score: float = self.ranker(query, keywords_content, score_cutoff=cutoff_score)
                     semantic_score: float = doc.score
                     fusion_score: float = self.compute_fusion_score(
                         distance=semantic_score,
@@ -253,9 +221,7 @@ class GammaHybridRetriever(IRetrieverRunner):
                 # Sort by fusion score and get top-k
                 fus_topk = sorted(
                     fus_topk,
-                    key=cmp_to_key(
-                        lambda obj1, obj2: obj1["fusion_score"] - obj2["fusion_score"]
-                    ),
+                    key=cmp_to_key(lambda obj1, obj2: obj1["fusion_score"] - obj2["fusion_score"]),
                     reverse=True,
                 )[:top_k]
                 res_topk = [res_topp[pos["rank"]] for pos in fus_topk]  # type: ignore
@@ -280,9 +246,7 @@ class HybridRetriever(IRetrieverRunner):
         self.processor = processor
         self.device = device
         if runner.device != device:
-            logger.info(
-                f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}"
-            )
+            logger.info(f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}")
             runner.to(device)
         self.runner = runner.eval()
         self.alpha = alpha
@@ -305,33 +269,20 @@ class HybridRetriever(IRetrieverRunner):
         prefix = self.prefix if prefix is None else prefix
         single_query = isinstance(queries, str)
         queries = [queries] if single_query else queries
-        js_queries = [
-            (
-                {"content": q}
-                if prefix is None
-                else {"content": q, "meta": {"prefix": prefix}}
-            )
-            for q in queries
-        ]
+        js_queries = [({"content": q} if prefix is None else {"content": q, "meta": {"prefix": prefix}}) for q in queries]
         dataset, tensor_names = igniset(
             js_queries,
             processor=self.processor,
             batch_size=batch_size,
             streaming=streaming_preprocessing,
         )
-        loader = NamedDataLoader(
-            dataset, tensor_names=tensor_names, batch_size=batch_size
-        )
+        loader = NamedDataLoader(dataset, tensor_names=tensor_names, batch_size=batch_size)
         answer = []
 
-        for _queries, _batches in zip(
-            chunked(queries, n=batch_size), loader, strict=False
-        ):
+        for _queries, _batches in zip(chunked(queries, n=batch_size), loader, strict=False):
             batches = {k: v.to(self.device) for k, v in _batches.items()}
             with torch.no_grad():
-                vectors = (
-                    self.runner(batch=batches)[0].cpu().numpy().tolist()
-                )  # batch_size x vector_dim
+                vectors = self.runner(batch=batches)[0].cpu().numpy().tolist()  # batch_size x vector_dim
             answer_per_batch = await self.store.search(
                 queries=_queries,
                 queries_embeddings=vectors,
@@ -363,9 +314,7 @@ class EmbeddingRetriever(IRetrieverRunner):
         self.processor = processor
         self.device = device
         if runner.device != device:
-            logger.info(
-                f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}"
-            )
+            logger.info(f"Moving [{runner.__class__.__name__}] to the new device = {device}. Old device = {runner.device}")
             runner.to(device)
         self.runner = runner.eval()
         self.prefix = prefix
@@ -387,32 +336,19 @@ class EmbeddingRetriever(IRetrieverRunner):
         prefix = self.prefix if prefix is None else prefix
         single_query = isinstance(queries, str)
         queries = [queries] if single_query else queries
-        js_queries = [
-            (
-                {"content": q}
-                if prefix is None
-                else {"content": q, "meta": {"prefix": prefix}}
-            )
-            for q in queries
-        ]
+        js_queries = [({"content": q} if prefix is None else {"content": q, "meta": {"prefix": prefix}}) for q in queries]
         dataset, tensor_names = igniset(
             js_queries,
             processor=self.processor,
             batch_size=batch_size,
             streaming=streaming_preprocessing,
         )
-        loader = NamedDataLoader(
-            dataset, tensor_names=tensor_names, batch_size=batch_size
-        )
+        loader = NamedDataLoader(dataset, tensor_names=tensor_names, batch_size=batch_size)
         answer = []
-        for _queries, _batches in zip(
-            chunked(queries, n=batch_size), loader, strict=False
-        ):
+        for _queries, _batches in zip(chunked(queries, n=batch_size), loader, strict=False):
             batches = {k: v.to(self.device) for k, v in _batches.items()}
             with torch.no_grad():
-                vectors = (
-                    self.runner(batch=batches)[0].cpu().numpy().tolist()
-                )  # batch_size x vector_dim
+                vectors = self.runner(batch=batches)[0].cpu().numpy().tolist()  # batch_size x vector_dim
             answer_per_batch = await self.store.search_by_embedding(
                 queries_embeddings=vectors,
                 top_k=top_k,
@@ -443,9 +379,7 @@ class KeywordsRetriever(IRetrieverRunner):
     ):
         single_query = isinstance(queries, str)
         queries = [queries] if single_query else queries
-        answer = self.store.search_by_keywords_sync(
-            queries=queries, top_k=top_k, filters=filters, keywords=keywords
-        )
+        answer = self.store.search_by_keywords_sync(queries=queries, top_k=top_k, filters=filters, keywords=keywords)
         answer = _coerce_results_per_query(answer, n_queries=len(queries))
         return answer[0] if single_query else answer
 
@@ -460,9 +394,7 @@ class KeywordsRetriever(IRetrieverRunner):
     ):
         single_query = isinstance(queries, str)
         queries = [queries] if single_query else queries
-        answer = await self.store.search_by_keywords(
-            queries=queries, top_k=top_k, filters=filters, keywords=keywords
-        )
+        answer = await self.store.search_by_keywords(queries=queries, top_k=top_k, filters=filters, keywords=keywords)
         answer = _coerce_results_per_query(answer, n_queries=len(queries))
         return answer[0] if single_query else answer
 
@@ -481,10 +413,7 @@ class ByName:
         elif name == "gamma-hybrid":
             klass = GammaHybridRetriever
         else:
-            msg = (
-                f"Unknown name=[{name}] to init IRetrieverRunner instance. "
-                f"Use one of {','.join(self.OPS)}"
-            )
+            msg = f"Unknown name=[{name}] to init IRetrieverRunner instance. " f"Use one of {','.join(self.OPS)}"
             logger.error(msg)
             raise ValueError(msg)
 

--- a/justatom/running/service.py
+++ b/justatom/running/service.py
@@ -7,19 +7,17 @@ from typing import Any
 import torch
 from loguru import logger
 
-from justatom.etc.errors import DocumentStoreError
 from justatom.configuring.builtins import load_builtin_yaml
+from justatom.etc.errors import DocumentStoreError
 from justatom.modeling.mask import ILanguageModel
 from justatom.processing import ITokenizer, RuntimeProcessor
+from justatom.running.embeddings import EmbeddingClientFactory, IEmbeddingClient
 from justatom.running.encoders import EncoderRunner
-from justatom.running.embeddings import EmbeddingClientFactory
-from justatom.running.embeddings import IEmbeddingClient
 from justatom.running.indexer import API as IndexerAPI
 from justatom.running.mask import IRetrieverRunner
 from justatom.running.retriever import API as RetrieverApi
 from justatom.storing.weaviate import Finder as WeaviateApi
 from justatom.storing.weaviate import WeaviateDocStore
-
 
 LM_CACHE_MAXSIZE = int(os.getenv("RUNNING_MODEL_CACHE_SIZE", "4"))
 TOKENIZER_CACHE_MAXSIZE = int(os.getenv("RUNNING_TOKENIZER_CACHE_SIZE", "4"))
@@ -223,27 +221,19 @@ class RunningService:
             device=device,
             max_seq_len=max_seq_len,
         )
-        cached_client = RunningService._cache_get(
-            RunningService._embedding_clients, cache_key
-        )
+        cached_client = RunningService._cache_get(RunningService._embedding_clients, cache_key)
         if cached_client is not None:
             return cached_client
 
         normalized_backend = backend.strip().lower()
         if normalized_backend in {"openai", "openai-compatible", "openai_compatible"}:
             defaults = RunningService._embedding_openai_defaults()
-            resolved_base_url = (
-                base_url or os.getenv("EMBEDDING_BASE_URL") or ""
-            ).strip()
+            resolved_base_url = (base_url or os.getenv("EMBEDDING_BASE_URL") or "").strip()
             resolved_api_key = (api_key or os.getenv("EMBEDDING_API_KEY") or "").strip()
             if resolved_base_url == "":
-                raise ValueError(
-                    "`base_url` or `EMBEDDING_BASE_URL` is required for openai backend"
-                )
+                raise ValueError("`base_url` or `EMBEDDING_BASE_URL` is required for openai backend")
             if resolved_api_key == "":
-                raise ValueError(
-                    "`api_key` or `EMBEDDING_API_KEY` is required for openai backend"
-                )
+                raise ValueError("`api_key` or `EMBEDDING_API_KEY` is required for openai backend")
 
             client = EmbeddingClientFactory.from_backend(
                 normalized_backend,
@@ -258,11 +248,7 @@ class RunningService:
                 prefix_skip_if_present=defaults["prefix_skip_if_present"],
                 default_pooling=defaults["default_pooling"],
                 default_encoding_format=defaults["default_encoding_format"],
-                default_max_seq_len=(
-                    max_seq_len
-                    if max_seq_len is not None
-                    else defaults["default_max_seq_len"]
-                ),
+                default_max_seq_len=(max_seq_len if max_seq_len is not None else defaults["default_max_seq_len"]),
             )
         else:
             client = EmbeddingClientFactory.from_backend(
@@ -379,17 +365,13 @@ class RunningService:
         RunningService._embedding_clients.clear()
 
     @staticmethod
-    async def check_store_and_message(
-        store: WeaviateDocStore, delete_if_not_empty: bool
-    ):
+    async def check_store_and_message(store: WeaviateDocStore, delete_if_not_empty: bool):
         n_docs_count: int = await store.count_documents()
         collection_name = store.collection_name
         if delete_if_not_empty:
             status_message: bool = await store.delete_all_documents()
             if not status_message:
-                raise DocumentStoreError(
-                    f"Documents per collection {collection_name} are not deleted. See logs for more details"
-                )
+                raise DocumentStoreError(f"Documents per collection {collection_name} are not deleted. See logs for more details")
         elif n_docs_count > 0:
             logger.warning(
                 f"You're not deleting any documents. Using pre-built {n_docs_count} documents per collection {collection_name}"
@@ -437,9 +419,7 @@ class RunningService:
         **props,
     ):
         if search_pipeline == "keywords":
-            return IndexerAPI.named(search_pipeline, store=store), RetrieverApi.named(
-                search_pipeline, store=store
-            )
+            return IndexerAPI.named(search_pipeline, store=store), RetrieverApi.named(search_pipeline, store=store)
 
         if model_name_or_path is None:
             msg = f"You have specified `runner_name`=[{search_pipeline}] but `model_name_or_path` is None."
@@ -491,12 +471,8 @@ class RunningService:
         weaviate_port: int = 2211,
         **props,
     ) -> IRetrieverRunner:
-        store: WeaviateDocStore = await WeaviateApi.find(
-            collection_name, WEAVIATE_HOST=weaviate_host, WEAVIATE_PORT=weaviate_port
-        )
-        store, n_total_docs = await RunningService.check_store_and_message(
-            store, delete_if_not_empty=flush_collection
-        )
+        store: WeaviateDocStore = await WeaviateApi.find(collection_name, WEAVIATE_HOST=weaviate_host, WEAVIATE_PORT=weaviate_port)
+        store, n_total_docs = await RunningService.check_store_and_message(store, delete_if_not_empty=flush_collection)
         device = RunningService.maybe_cuda_or_mps(devices=devices)
 
         ix_runner, ir_runner = RunningService.igni_runners(
@@ -512,9 +488,7 @@ class RunningService:
             return ir_runner
 
         logger.info("Indexing in progress")
-        n_total_docs = await ix_runner.index(
-            documents=documents, batch_size=batch_size, device=device
-        )
+        n_total_docs = await ix_runner.index(documents=documents, batch_size=batch_size, device=device)
         logger.info(f"Total docs in index {n_total_docs}")
         return ir_runner
 

--- a/justatom/storing/dataset.py
+++ b/justatom/storing/dataset.py
@@ -23,7 +23,6 @@ from justatom.configuring.builtins import resolve_builtin_path
 from justatom.etc.pattern import singleton
 from justatom.storing.mask import IDataset
 
-
 _HF_REPO_DATASET_RE = re.compile(r"^[^/\s]+/[^/\s]+(?:\?.*)?$")
 _HF_TOKEN_ENV_NAMES = ("HF_TOKEN", "HUGGINGFACE_HUB_TOKEN", "HF_HUB_TOKEN", "HF_API_KEY")
 

--- a/justatom/storing/mask.py
+++ b/justatom/storing/mask.py
@@ -10,9 +10,7 @@ from justatom.etc.schema import Document
 try:
     from numba import njit  # pylint: disable=import-error
 except (ImportError, ModuleNotFoundError):
-    logger.debug(
-        "Numba not found, replacing njit() with no-op implementation. Enable it with 'pip install numba'."
-    )
+    logger.debug("Numba not found, replacing njit() with no-op implementation. Enable it with 'pip install numba'.")
 
     def njit(f):
         return f
@@ -93,9 +91,7 @@ class INNDocStore(abc.ABC):
         pass
 
     @abc.abstractclassmethod
-    def get_document_by_id(
-        self, id: str, headers: dict[str, str] | None = None
-    ) -> Document | None:
+    def get_document_by_id(self, id: str, headers: dict[str, str] | None = None) -> Document | None:
         pass
 
     @abc.abstractmethod
@@ -142,9 +138,7 @@ class INNDocStore(abc.ABC):
         self.ids_iterator = self.ids_iterator[1:]
         return ret
 
-    def _drop_duplicate_documents(
-        self, documents: list[Document], index: str | None = None
-    ) -> list[Document]:
+    def _drop_duplicate_documents(self, documents: list[Document], index: str | None = None) -> list[Document]:
         """
         Drop duplicates documents based on same hash ID
         :param documents: A list of Document objects.
@@ -192,9 +186,7 @@ class INNDocStore(abc.ABC):
         index = index or self.index
         if duplicate_documents in ("skip", "fail"):
             documents = self._drop_duplicate_documents(documents, index)
-            documents_found = self.get_documents_by_id(
-                ids=[doc.id for doc in documents], index=index, headers=headers
-            )
+            documents_found = self.get_documents_by_id(ids=[doc.id for doc in documents], index=index, headers=headers)
             ids_exist_in_db: list[str] = [doc.id for doc in documents_found]
 
             if len(ids_exist_in_db) > 0 and duplicate_documents == "fail":
@@ -202,9 +194,7 @@ class INNDocStore(abc.ABC):
                     f"Document with ids '{', '.join(ids_exist_in_db)} already exists in index = '{index}'."
                 )
 
-            documents = list(
-                filter(lambda doc: doc.id not in ids_exist_in_db, documents)
-            )
+            documents = list(filter(lambda doc: doc.id not in ids_exist_in_db, documents))
 
         return documents
 

--- a/justatom/tooling/dataset.py
+++ b/justatom/tooling/dataset.py
@@ -1,5 +1,5 @@
-import json
 import inspect
+import json
 from collections.abc import Generator, Iterable
 from itertools import islice
 from pathlib import Path
@@ -11,8 +11,8 @@ from json_repair import loads as json_repair_loads
 from loguru import logger
 
 from justatom.etc.schema import Document
-from justatom.tooling.profiler import MemoryProfiler
 from justatom.storing.dataset import API as DatasetApi
+from justatom.tooling.profiler import MemoryProfiler
 
 
 class DatasetRecordAdapter:

--- a/justatom/tooling/mmarco_selected.py
+++ b/justatom/tooling/mmarco_selected.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import polars as pl
 
-
 SOURCE_DATASET = "ir_datasets:mmarco/v2/ru"
 DEFAULT_REPO_ID = "justatom/mmarco-ru-selected"
 HF_TOKEN_ENV_NAMES = ("HF_TOKEN", "HUGGINGFACE_HUB_TOKEN", "HF_HUB_TOKEN", "HF_API_KEY")

--- a/justatom/tooling/mmarco_selected.py
+++ b/justatom/tooling/mmarco_selected.py
@@ -5,7 +5,7 @@ import json
 import os
 import random
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -98,7 +98,7 @@ def write_manifest(
     manifest = {
         "repo_id": repo_id,
         "source": SOURCE_DATASET,
-        "created_at_utc": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "created_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         "selection": asdict(cfg),
         "counts": counts,
         "splits": {

--- a/justatom/training/alpha_gate.py
+++ b/justatom/training/alpha_gate.py
@@ -7,7 +7,6 @@ from torch import nn
 
 from justatom.training.config import AlphaGateConfig
 
-
 _ACTIVATIONS: dict[str, type[nn.Module]] = {
     "gelu": nn.GELU,
     "relu": nn.ReLU,

--- a/justatom/training/config.py
+++ b/justatom/training/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field, fields, is_dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, TypeVar
 
 
 class TrainingMethod(str, Enum):
@@ -185,7 +185,10 @@ def _path(parent: str, child: str) -> str:
     return f"{parent}.{child}" if parent else child
 
 
-def _enum_value(enum_type: type[Enum], value: Any, path: str) -> Enum:
+EnumType = TypeVar("EnumType", bound=Enum)
+
+
+def _enum_value(enum_type: type[EnumType], value: Any, path: str) -> EnumType:
     if isinstance(value, enum_type):
         return value
     try:

--- a/justatom/training/data.py
+++ b/justatom/training/data.py
@@ -73,10 +73,26 @@ def _iterate_from_raw_samples(
 
 def _iterate_from_frame_batches(
     frame_batches: Iterable[pl.DataFrame],
-    **kwargs: Any,
+    *,
+    content_field: str,
+    labels_field: str,
+    chunk_id_col: str | None,
+    keywords_or_phrases_field: str | None,
+    keywords_nested_col: str | None,
+    explanation_nested_col: str | None,
+    filters: dict | None,
 ) -> Generator[dict[str, Any], None, None]:
     for batch in frame_batches:
-        yield from _iterate_from_raw_samples(batch.iter_rows(named=True), **kwargs)
+        yield from _iterate_from_raw_samples(
+            batch.iter_rows(named=True),
+            content_field=content_field,
+            labels_field=labels_field,
+            chunk_id_col=chunk_id_col,
+            keywords_or_phrases_field=keywords_or_phrases_field,
+            keywords_nested_col=keywords_nested_col,
+            explanation_nested_col=explanation_nested_col,
+            filters=filters,
+        )
 
 
 def _frame_batches_from_source(
@@ -117,18 +133,18 @@ def iterate_training_rows(
 ) -> Iterable[dict[str, Any]]:
     if dataset_name_or_path is None:
         raise ValueError("dataset_name_or_path must be provided for training")
-    source_kwargs = {
-        "content_field": content_field,
-        "labels_field": labels_field,
-        "chunk_id_col": chunk_id_col,
-        "keywords_or_phrases_field": keywords_or_phrases_field,
-        "keywords_nested_col": keywords_nested_col,
-        "explanation_nested_col": explanation_nested_col,
-        "filters": filters,
-    }
     frame_batches = _frame_batches_from_source(dataset_name_or_path=dataset_name_or_path, split=split)
     if frame_batches is not None:
-        rows = _iterate_from_frame_batches(frame_batches, **source_kwargs)
+        rows = _iterate_from_frame_batches(
+            frame_batches,
+            content_field=content_field,
+            labels_field=labels_field,
+            chunk_id_col=chunk_id_col,
+            keywords_or_phrases_field=keywords_or_phrases_field,
+            keywords_nested_col=keywords_nested_col,
+            explanation_nested_col=explanation_nested_col,
+            filters=filters,
+        )
         return rows if limit is None else islice(rows, int(limit))
 
     docs_adapter = DatasetRecordAdapter.from_source(

--- a/justatom/training/job.py
+++ b/justatom/training/job.py
@@ -15,11 +15,7 @@ from justatom.processing import ITokenizer, igniset
 from justatom.processing.loader import NamedDataLoader
 from justatom.processing.prime import TrainWithContrastiveProcessor
 from justatom.running.encoders import EncoderRunner
-from justatom.tooling.collections import (
-    build_collection_metadata,
-    resolve_artifact_dirname,
-    write_collection_metadata,
-)
+from justatom.tooling.collections import build_collection_metadata, resolve_artifact_dirname, write_collection_metadata
 from justatom.training.config import RuntimeConfig, TrainConfig, train_config_to_dict
 from justatom.training.data import prepare_training_data_from_config
 from justatom.training.methods import resolve_method

--- a/justatom/training/module.py
+++ b/justatom/training/module.py
@@ -10,12 +10,7 @@ from torch import nn
 
 from justatom.logging.io import CSVLogger
 from justatom.training.alpha_gate import QueryAlphaGate
-from justatom.training.config import (
-    MarginMode,
-    TrainConfig,
-    parse_train_config,
-    train_config_to_dict,
-)
+from justatom.training.config import MarginMode, TrainConfig, parse_train_config, train_config_to_dict
 from justatom.training.memory_bank import ContrastiveMemoryBank, QueryMarginHead
 from justatom.training.methods import resolve_method
 from justatom.training.objective import ContrastiveObjective, ObjectiveInputs, ObjectiveOutput

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 site_name: justatom
 site_description: Neural retrieval, indexing, training, and evaluation toolkit.
 
+exclude_docs: |
+  superpowers/
+
 theme:
   name: material
   logo: Logo.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,37 @@ name = "justatom"
 version = "0.1.0"
 requires-python = ">=3.10"
 
+[project.optional-dependencies]
+torch = [
+  "torch==2.8.0",
+  "pytorch-lightning==2.2.1",
+  "torchmetrics==1.3.2",
+  "transformers>=4.44,<6",
+]
+test = [
+  "pytest>=8,<9",
+  "setuptools<81",
+  "lazy-imports==0.3.1",
+  "fastnumbers==5.1.0",
+  "json-repair==0.30.0",
+  "mmh3==4.1.0",
+  "more-itertools==10.1.0",
+  "pandas>=2.2,<3",
+  "python-dateutil==2.9.0.post0",
+  "polars==1.38.1",
+  "weaviate-client==4.11.3",
+  "loguru==0.7.2",
+  "tqdm",
+  "PyYAML>=6,<7",
+  "python-dotenv==1.0.0",
+  "simplejson==3.19.2",
+  "dotmap==1.3.30",
+  "envyaml==1.10.211231",
+  "jsonlines==4.0.0",
+  "jarowinkler==2.0.1",
+  "openai>=1,<3",
+]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ testpaths = [
 ]
 markers = [
   "integration: tests that require external services (e.g. Weaviate/Docker)",
+  "network: tests that download external models or datasets",
 ]
 
 [tool.black]

--- a/tests/test_benchmark_variants.py
+++ b/tests/test_benchmark_variants.py
@@ -3,7 +3,6 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_benchmark_variants.py
+++ b/tests/test_benchmark_variants.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import unittest
 from pathlib import Path
@@ -7,6 +8,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class BenchmarkVariantTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "benchmark shell tests require a Unix environment")
     def test_all_variants_are_vanilla_atom_gate_and_atomic(self):
         with TemporaryDirectory() as tmpdir:
             bench_root = Path(tmpdir) / "bench"
@@ -39,6 +41,7 @@ class BenchmarkVariantTests(unittest.TestCase):
             self.assertIn("## atomic", commands)
             self.assertNotIn("## bank_only", commands)
 
+    @unittest.skipIf(os.name == "nt", "benchmark shell tests require a Unix environment")
     def test_atomic_variant_delegates_canonical_defaults_to_method_profile(self):
         with TemporaryDirectory() as tmpdir:
             bench_root = Path(tmpdir) / "bench"
@@ -69,6 +72,7 @@ class BenchmarkVariantTests(unittest.TestCase):
             self.assertNotIn("--recipe", commands)
             self.assertNotIn("--memory-bank-size", commands)
 
+    @unittest.skipIf(os.name == "nt", "benchmark shell tests require a Unix environment")
     def test_retired_bank_variant_points_to_atomic(self):
         result = subprocess.run(
             [

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 
+import pytest
 import torch
 from loguru import logger
 from tqdm.auto import tqdm
@@ -12,6 +13,8 @@ from justatom.processing.prime import RuntimeProcessor
 from justatom.processing.tokenizer import ITokenizer
 from justatom.running.encoders import EncoderRunner
 from justatom.running.mask import IModelRunner
+
+pytestmark = pytest.mark.network
 
 
 class M1LMRunnerTest(unittest.TestCase):

--- a/tests/test_eval_data_normalization.py
+++ b/tests/test_eval_data_normalization.py
@@ -42,10 +42,13 @@ class EvalDataNormalizationTest(unittest.TestCase):
             }
         ]
 
-        with patch.dict(
-            os.environ,
-            {"HF_TOKEN": "", "HUGGINGFACE_HUB_TOKEN": "", "HF_HUB_TOKEN": "", "HF_API_KEY": ""},
-        ), patch("justatom.storing.dataset.load_dataset", return_value=rows) as mocked:
+        with (
+            patch.dict(
+                os.environ,
+                {"HF_TOKEN": "", "HUGGINGFACE_HUB_TOKEN": "", "HF_HUB_TOKEN": "", "HF_API_KEY": ""},
+            ),
+            patch("justatom.storing.dataset.load_dataset", return_value=rows) as mocked,
+        ):
             adapter = DatasetRecordAdapter.from_source(
                 dataset_name_or_path="hf://miracl/miracl?config=ru&split=train",
                 content_col="text",
@@ -80,10 +83,13 @@ class EvalDataNormalizationTest(unittest.TestCase):
             }
         ]
 
-        with patch.dict(
-            os.environ,
-            {"HF_TOKEN": "", "HUGGINGFACE_HUB_TOKEN": "", "HF_HUB_TOKEN": "", "HF_API_KEY": ""},
-        ), patch("justatom.storing.dataset.load_dataset", return_value=rows) as mocked:
+        with (
+            patch.dict(
+                os.environ,
+                {"HF_TOKEN": "", "HUGGINGFACE_HUB_TOKEN": "", "HF_HUB_TOKEN": "", "HF_API_KEY": ""},
+            ),
+            patch("justatom.storing.dataset.load_dataset", return_value=rows) as mocked,
+        ):
             adapter = DatasetRecordAdapter.from_source(
                 dataset_name_or_path="justatom/meme-russian-ir",
                 content_col="text",

--- a/tests/test_eval_data_normalization.py
+++ b/tests/test_eval_data_normalization.py
@@ -265,6 +265,7 @@ class EvalDataNormalizationTest(unittest.TestCase):
 
     def test_from_source_respects_lazy_materialization_contract(self):
         fd, path = tempfile.mkstemp(suffix=".json", prefix="adapter_source_")
+        os.close(fd)
         Path(path).unlink(missing_ok=True)
         data_path = Path(path)
         data_path.write_text(
@@ -304,6 +305,7 @@ class EvalDataNormalizationTest(unittest.TestCase):
 
     def test_from_source_supports_parquet_with_custom_columns(self):
         fd, path = tempfile.mkstemp(suffix=".parquet", prefix="adapter_source_")
+        os.close(fd)
         Path(path).unlink(missing_ok=True)
         data_path = Path(path)
 
@@ -340,6 +342,7 @@ class EvalDataNormalizationTest(unittest.TestCase):
 
     def test_from_source_lazy_json_warns_and_falls_back_to_eager_load(self):
         fd, path = tempfile.mkstemp(suffix=".json", prefix="adapter_streaming_")
+        os.close(fd)
         Path(path).unlink(missing_ok=True)
         data_path = Path(path)
         rows = [
@@ -367,6 +370,7 @@ class EvalDataNormalizationTest(unittest.TestCase):
 
     def test_from_source_lazy_json_wrapped_payload_warns_and_still_loads(self):
         fd, path = tempfile.mkstemp(suffix=".json", prefix="adapter_wrapped_")
+        os.close(fd)
         Path(path).unlink(missing_ok=True)
         data_path = Path(path)
         data_path.write_text(

--- a/tests/test_eval_streaming_integration.py
+++ b/tests/test_eval_streaming_integration.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import random
 import string
 import subprocess
@@ -61,6 +62,7 @@ class EvalStreamingIntegrationTest(unittest.TestCase):
     @staticmethod
     def _dummy_iterative_dataset(n_docs: int = 100) -> str:
         fd, path = tempfile.mkstemp(suffix=".jsonl", prefix="eval_streaming_")
+        os.close(fd)
         Path(path).unlink(missing_ok=True)
         data_path = Path(path)
         with data_path.open("w", encoding="utf-8") as f:

--- a/tests/test_memory_bank.py
+++ b/tests/test_memory_bank.py
@@ -4,12 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from justatom.training.config import (
-    AdaptiveBankConfig,
-    MarginConfig,
-    MarginMode,
-    MemoryBankConfig,
-)
+from justatom.training.config import AdaptiveBankConfig, MarginConfig, MarginMode, MemoryBankConfig
 from justatom.training.memory_bank import ContrastiveMemoryBank, MemorySelection, QueryMarginHead
 
 

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_running_mask_import_does_not_require_bertopic() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script = """
+import builtins
+
+original_import = builtins.__import__
+
+def import_without_bertopic(name, *args, **kwargs):
+    if name == "bertopic" or name.startswith("bertopic."):
+        raise ModuleNotFoundError("bertopic intentionally unavailable")
+    return original_import(name, *args, **kwargs)
+
+builtins.__import__ = import_without_bertopic
+from justatom.running.mask import ICLUSTERINGWrapperBackend
+
+assert ICLUSTERINGWrapperBackend.__name__ == "ICLUSTERINGWrapperBackend"
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_qwen3_embedding_model.py
+++ b/tests/test_qwen3_embedding_model.py
@@ -1,5 +1,5 @@
-from types import SimpleNamespace
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch

--- a/tests/test_resource_snapshot.py
+++ b/tests/test_resource_snapshot.py
@@ -20,8 +20,7 @@ class ResourceSnapshotTest(unittest.TestCase):
 
         self.assertEqual(
             line,
-            "RSS justatom tune: self_pid=123 self_rss_mb=1.5 "
-            "top=[456:python:2.0MB, 789:weaviate:1.0MB]",
+            "RSS justatom tune: self_pid=123 self_rss_mb=1.5 " "top=[456:python:2.0MB, 789:weaviate:1.0MB]",
         )
 
     def test_cli_emits_snapshot_for_requested_pid(self):
@@ -51,8 +50,8 @@ class ResourceSnapshotTest(unittest.TestCase):
         benchmark = Path("scripts/run_benchmark.sh").read_text()
 
         self.assertIn("justatom.tooling.resources", pipeline)
-        self.assertIn("log_rss \"before $label\"", pipeline)
-        self.assertIn("log_rss \"after $label\"", pipeline)
+        self.assertIn('log_rss "before $label"', pipeline)
+        self.assertIn('log_rss "after $label"', pipeline)
         self.assertIn("justatom.tooling.resources", benchmark)
 
 

--- a/tests/test_retriever_shape_and_factory.py
+++ b/tests/test_retriever_shape_and_factory.py
@@ -17,14 +17,12 @@ if "bertopic" not in sys.modules:
     sys.modules["bertopic.backend"] = backend_mod
 
 from justatom.etc.schema import Document
+from justatom.running.indexer import API as IndexerAPI
 from justatom.running.retriever import API as RetrieverAPI
 from justatom.running.retriever import KeywordsRetriever
-from justatom.running.indexer import API as IndexerAPI
 
 
-def _mk_doc(
-    content: str, labels: list[str] | None = None, score: float = 1.0
-) -> Document:
+def _mk_doc(content: str, labels: list[str] | None = None, score: float = 1.0) -> Document:
     payload = {
         "content": content,
         "meta": {"labels": labels or []},

--- a/tests/test_scenario_configs.py
+++ b/tests/test_scenario_configs.py
@@ -4,9 +4,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from justatom.configuring.builtins import resolve_builtin_path
 from justatom.api.eval import resolve_eval_kwargs
 from justatom.api.train import resolve_train_config
+from justatom.configuring.builtins import resolve_builtin_path
 from justatom.configuring.scenarios import load_scenario_config
 from justatom.etc.errors import DocumentStoreError
 from justatom.storing.weaviate import WeaviateDocStore

--- a/tests/test_train_data_preparation.py
+++ b/tests/test_train_data_preparation.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -6,7 +7,8 @@ from justatom.training import data as training_data
 
 
 def _write_jsonl(rows: list[dict]) -> Path:
-    _, raw_path = tempfile.mkstemp(suffix=".jsonl", prefix="train_prepare_")
+    fd, raw_path = tempfile.mkstemp(suffix=".jsonl", prefix="train_prepare_")
+    os.close(fd)
     path = Path(raw_path)
     with path.open("w", encoding="utf-8") as stream:
         for row in rows:

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from justatom.training.config import (
-    ExperimentRole,
-    MarginMode,
-    TrainingMethod,
-    parse_train_config,
-    train_config_to_dict,
-)
+from justatom.training.config import ExperimentRole, MarginMode, TrainingMethod, parse_train_config, train_config_to_dict
 
 
 def test_parse_train_config_builds_typed_atomic_config():

--- a/tests/test_training_job.py
+++ b/tests/test_training_job.py
@@ -6,12 +6,7 @@ from pathlib import Path
 import yaml
 
 from justatom.training.config import TrainingMethod
-from justatom.training.job import (
-    RunManifest,
-    TrainingJob,
-    artifact_paths,
-    write_run_manifest,
-)
+from justatom.training.job import RunManifest, TrainingJob, artifact_paths, write_run_manifest
 from justatom.training.methods import canonical_method_config
 
 

--- a/tests/test_training_telemetry.py
+++ b/tests/test_training_telemetry.py
@@ -2,12 +2,7 @@ from __future__ import annotations
 
 import torch
 
-from justatom.training.telemetry import (
-    batch_retrieval_metrics,
-    grad_norm,
-    resolve_metric_tensors,
-    scalar_distribution,
-)
+from justatom.training.telemetry import batch_retrieval_metrics, grad_norm, resolve_metric_tensors, scalar_distribution
 
 
 def test_scalar_distribution_has_stable_quantiles():


### PR DESCRIPTION
## Summary
- declare reproducible `torch` and `test` extras and limit CI to supported Python versions
- make optional BERTopic imports safe and tighten the typed training checks
- fix Black/isort, Pylint/mypy, MkDocs build, and same-repository docs deployment
- make the test suite portable across macOS, Windows, and Python 3.10
- isolate external Hugging Face downloads behind the `network` marker

## Verification
- clean `pip install .[torch,test]`
- required suite: `151 passed` (`not integration and not network`)
- network model tests: 2 collected via `pytest -m network`
- Weaviate integration: `1 passed`
- Black 24.10.0 + isort 5.13.2
- Pylint 4.0.6 + mypy 2.3.0
- `mkdocs build --strict`
- `compileall`
- GitHub Actions: all 9 CI jobs and Docs check passed
