### PR TITLE
Add portable PEFT LoRA training configs

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -10,6 +10,14 @@ model:
   content_prefix: "passage:"
   max_query_seq_len: null
   max_seq_len: 512
+  lora:
+    enabled: false
+    rank: 16
+    alpha: 32
+    dropout: 0.0
+    target_modules: all-linear
+    use_rslora: true
+    bias: none
 
 dataset:
   id: null
@@ -59,3 +67,5 @@ artifacts:
 runtime:
   accelerator: auto
   devices: auto
+  precision: auto
+  gradient_checkpointing: false

--- a/docs/training.md
+++ b/docs/training.md
@@ -118,14 +118,65 @@ bash scripts/run_benchmark.sh \
   --auto-e5-prefixes
 ```
 
+## LoRA adapters
+
+LoRA is an encoder configuration, so it composes with every training method.
+The objective, query gate, and memory bank do not change; the optimizer simply
+updates PEFT adapter parameters instead of the frozen backbone parameters.
+
+The default `all-linear` target is resolved by PEFT from the Hugging Face model
+itself. This keeps the same config usable for Qwen3-Embedding, E5, BGE, and
+mBERT. An explicit list is still available for controlled experiments.
+`justatom/pfbert` is intentionally unsupported because it is not a Hugging Face
+encoder.
+
+```yaml
+method: atomic
+
+model:
+  name_or_path: Qwen/Qwen3-Embedding-0.6B
+  query_prefix: |-
+    Instruct: Given a web search query, retrieve relevant passages that answer the query
+    Query:
+  content_prefix: ""
+  lora:
+    enabled: true
+    rank: 16
+    alpha: 32
+    dropout: 0.05
+    target_modules: all-linear
+    use_rslora: true
+    bias: none
+
+optimization:
+  lr_encoder: 0.0002
+
+runtime:
+  accelerator: auto
+  precision: auto
+  gradient_checkpointing: true
+```
+
+This is ordinary Hugging Face PEFT; it does not require Unsloth, bitsandbytes,
+or a quantized base model. With `precision: auto`, CUDA uses BF16 when the GPU
+supports it and otherwise FP16. MPS and CPU default to FP32 for compatibility;
+`16-mixed` can be selected explicitly on a supported Mac. Gradient
+checkpointing is independent of LoRA and can be enabled when sequence length
+or batch size needs more memory.
+
 ## Artifacts
 
 Every successful training run writes:
 
 - `encoder/`: deployable Hugging Face-compatible encoder artifact
+- `adapter/`: PEFT adapter and its config when LoRA is enabled
 - `research/checkpoint.pt`: complete training state for analysis or continuation
 - `run_manifest.yaml`: resolved method, data, seed, hyperparameters, and Git state
 - `batch_metrics.csv`: losses, retrieval ranks, `alpha(q)`, bank geometry, collision `g(q)`, hard weights, and margin distributions
+
+The adapter and research checkpoint are saved before LoRA is merged into the
+deployable encoder. Loading `encoder/` therefore does not require PEFT, while
+`adapter/` retains the small reusable delta for reproducibility.
 
 The benchmark additionally writes commands, retrieval tables, geometry tables,
 and process RSS snapshots. These files are the reproducibility boundary for

--- a/justatom/builtins/configs/train.default.yaml
+++ b/justatom/builtins/configs/train.default.yaml
@@ -10,6 +10,14 @@ model:
   content_prefix: "passage:"
   max_query_seq_len: null
   max_seq_len: 512
+  lora:
+    enabled: false
+    rank: 16
+    alpha: 32
+    dropout: 0.0
+    target_modules: all-linear
+    use_rslora: true
+    bias: none
 
 dataset:
   id: null
@@ -59,3 +67,5 @@ artifacts:
 runtime:
   accelerator: auto
   devices: auto
+  precision: auto
+  gradient_checkpointing: false

--- a/justatom/processing/mask.py
+++ b/justatom/processing/mask.py
@@ -93,7 +93,9 @@ class IProcessor(abc.ABC):
         }
 
     def do_prefix(self, x: str, pref: str):
-        return pref.strip() + " " + x.strip()
+        prefix = pref.strip()
+        text = x.strip()
+        return f"{prefix} {text}" if prefix else text
 
     def _check_sample_features(self, basket: SampleBasket):
         """

--- a/justatom/training/config.py
+++ b/justatom/training/config.py
@@ -30,12 +30,24 @@ class ExperimentConfig:
 
 
 @dataclass(frozen=True)
+class LoraAdapterConfig:
+    enabled: bool = False
+    rank: int = 16
+    alpha: int = 32
+    dropout: float = 0.0
+    target_modules: str | tuple[str, ...] = "all-linear"
+    use_rslora: bool = True
+    bias: str = "none"
+
+
+@dataclass(frozen=True)
 class ModelConfig:
     name_or_path: str = "intfloat/multilingual-e5-small"
     query_prefix: str = "query:"
     content_prefix: str = "passage:"
     max_query_seq_len: int | None = None
     max_seq_len: int = 512
+    lora: LoraAdapterConfig = field(default_factory=LoraAdapterConfig)
 
 
 @dataclass(frozen=True)
@@ -153,6 +165,8 @@ class ArtifactConfig:
 class RuntimeConfig:
     accelerator: str = "auto"
     devices: str | int = "auto"
+    precision: str = "auto"
+    gradient_checkpointing: bool = False
 
 
 @dataclass(frozen=True)
@@ -253,6 +267,20 @@ def _normalize_dataset(raw: Any) -> Any:
     return normalized
 
 
+def _normalize_model(raw: Any) -> Any:
+    if not isinstance(raw, Mapping):
+        return raw
+    normalized = dict(raw)
+    lora = normalized.get("lora")
+    if isinstance(lora, Mapping):
+        lora = dict(lora)
+        target_modules = lora.get("target_modules")
+        if isinstance(target_modules, list):
+            lora["target_modules"] = tuple(target_modules)
+        normalized["lora"] = lora
+    return normalized
+
+
 def _require_bool(value: Any, path: str) -> None:
     if not isinstance(value, bool):
         raise ValueError(f"{path} must be a boolean")
@@ -281,6 +309,24 @@ def validate_train_config(config: TrainConfig) -> None:
     _require_int(config.model.max_seq_len, "model.max_seq_len", 1)
     if config.model.max_query_seq_len is not None:
         _require_int(config.model.max_query_seq_len, "model.max_query_seq_len", 1)
+    lora = config.model.lora
+    _require_bool(lora.enabled, "model.lora.enabled")
+    _require_int(lora.rank, "model.lora.rank", 1)
+    _require_int(lora.alpha, "model.lora.alpha", 1)
+    _require_number(lora.dropout, "model.lora.dropout", 0.0, 1.0)
+    _require_bool(lora.use_rslora, "model.lora.use_rslora")
+    if lora.bias not in {"none", "all", "lora_only"}:
+        raise ValueError("model.lora.bias must be one of: none, all, lora_only")
+    if isinstance(lora.target_modules, str):
+        if not lora.target_modules:
+            raise ValueError("model.lora.target_modules must be a non-empty string or list of strings")
+    elif isinstance(lora.target_modules, tuple):
+        if not lora.target_modules or not all(isinstance(name, str) and name for name in lora.target_modules):
+            raise ValueError("model.lora.target_modules must be a non-empty string or list of strings")
+    else:
+        raise ValueError("model.lora.target_modules must be a non-empty string or list of strings")
+    if lora.enabled and config.model.name_or_path == "justatom/pfbert":
+        raise ValueError("model.lora is supported only for Hugging Face encoders; justatom/pfbert is not supported")
 
     _require_bool(config.dataset.lazy, "dataset.lazy")
     if config.dataset.limit is not None:
@@ -343,6 +389,9 @@ def validate_train_config(config: TrainConfig) -> None:
     _require_bool(config.artifacts.save_research_checkpoint, "artifacts.save_research_checkpoint")
     if not isinstance(config.runtime.devices, (str, int)) or isinstance(config.runtime.devices, bool):
         raise ValueError("runtime.devices must be a string or integer")
+    if not isinstance(config.runtime.precision, str) or not config.runtime.precision:
+        raise ValueError("runtime.precision must be a non-empty string")
+    _require_bool(config.runtime.gradient_checkpointing, "runtime.gradient_checkpointing")
 
 
 def parse_train_config(raw: Mapping[str, Any]) -> TrainConfig:
@@ -357,6 +406,8 @@ def parse_train_config(raw: Mapping[str, Any]) -> TrainConfig:
     base = canonical_method_config(method)
     payload = dict(raw)
     payload.pop("method")
+    if "model" in payload:
+        payload["model"] = _normalize_model(payload["model"])
     if "dataset" in payload:
         payload["dataset"] = _normalize_dataset(payload["dataset"])
     config = _overlay_dataclass(base, payload)

--- a/justatom/training/job.py
+++ b/justatom/training/job.py
@@ -16,7 +16,7 @@ from justatom.processing.loader import NamedDataLoader
 from justatom.processing.prime import TrainWithContrastiveProcessor
 from justatom.running.encoders import EncoderRunner
 from justatom.tooling.collections import build_collection_metadata, resolve_artifact_dirname, write_collection_metadata
-from justatom.training.config import RuntimeConfig, TrainConfig, train_config_to_dict
+from justatom.training.config import LoraAdapterConfig, RuntimeConfig, TrainConfig, train_config_to_dict
 from justatom.training.data import prepare_training_data_from_config
 from justatom.training.methods import resolve_method
 from justatom.training.module import ContrastiveTrainingModule
@@ -26,6 +26,7 @@ from justatom.training.module import ContrastiveTrainingModule
 class ArtifactPaths:
     root: Path
     deployable_encoder: Path
+    adapter: Path
     research_checkpoint: Path
     manifest: Path
 
@@ -34,6 +35,7 @@ def artifact_paths(root: Path) -> ArtifactPaths:
     return ArtifactPaths(
         root=root,
         deployable_encoder=root / "encoder",
+        adapter=root / "adapter",
         research_checkpoint=root / "research" / "checkpoint.pt",
         manifest=root / "run_manifest.yaml",
     )
@@ -171,8 +173,49 @@ def resolve_torch_device(runtime: RuntimeConfig) -> str:
     return "cpu"
 
 
+def resolve_training_precision(runtime: RuntimeConfig) -> str:
+    if runtime.precision != "auto":
+        return runtime.precision
+    if resolve_torch_device(runtime).startswith("cuda"):
+        return "bf16-mixed" if torch.cuda.is_bf16_supported() else "16-mixed"
+    return "32-true"
+
+
+def apply_lora_adapter(language_model: ILanguageModel, config: LoraAdapterConfig) -> ILanguageModel:
+    if not config.enabled:
+        return language_model
+
+    from peft import LoraConfig, TaskType, get_peft_model
+
+    target_modules = list(config.target_modules) if isinstance(config.target_modules, tuple) else config.target_modules
+    language_model.model = get_peft_model(
+        language_model.model,
+        LoraConfig(
+            task_type=TaskType.FEATURE_EXTRACTION,
+            inference_mode=False,
+            r=config.rank,
+            lora_alpha=config.alpha,
+            lora_dropout=config.dropout,
+            target_modules=target_modules,
+            use_rslora=config.use_rslora,
+            bias=config.bias,
+        ),
+    )
+    return language_model
+
+
 def load_encoder(config: TrainConfig, processor: TrainWithContrastiveProcessor) -> EncoderRunner:
     language_model = ILanguageModel.load(model_name_or_path=config.model.name_or_path)
+    if config.runtime.gradient_checkpointing:
+        backbone = language_model.model
+        if not hasattr(backbone, "gradient_checkpointing_enable"):
+            raise ValueError(f"{config.model.name_or_path} does not support gradient checkpointing")
+        backbone.gradient_checkpointing_enable()
+        if hasattr(backbone, "enable_input_require_grads"):
+            backbone.enable_input_require_grads()
+        if hasattr(backbone, "config") and hasattr(backbone.config, "use_cache"):
+            backbone.config.use_cache = False
+    apply_lora_adapter(language_model, config.model.lora)
     return EncoderRunner(
         model=language_model,
         processor=processor,
@@ -199,6 +242,7 @@ def build_lightning_trainer(config: TrainConfig) -> L.Trainer:
         max_epochs=config.optimization.epochs,
         accelerator=config.runtime.accelerator,
         devices=config.runtime.devices,
+        precision=resolve_training_precision(config.runtime),
         accumulate_grad_batches=config.optimization.grad_acc_steps,
         logger=build_training_logger(config),
         log_every_n_steps=1,
@@ -213,6 +257,7 @@ class TrainingResult:
     encoder_dir: Path
     research_checkpoint: Path | None
     metrics_path: Path | None
+    adapter_dir: Path | None = None
 
 
 class TrainingJob:
@@ -249,7 +294,14 @@ class TrainingJob:
         trainer = self.trainer_factory(config)
         trainer.fit(module, train_dataloaders=loader)
 
-        encoder_dir = module.save_deployable_encoder(paths.deployable_encoder)
         checkpoint = module.save_research_checkpoint(paths.research_checkpoint)
+        adapter_dir = module.save_lora_adapter(paths.adapter)
+        encoder_dir = module.save_deployable_encoder(paths.deployable_encoder)
         metrics_path = None if module.metrics_path is None else Path(module.metrics_path)
-        return TrainingResult(paths.root, encoder_dir, checkpoint, metrics_path)
+        return TrainingResult(
+            run_dir=paths.root,
+            encoder_dir=encoder_dir,
+            research_checkpoint=checkpoint,
+            metrics_path=metrics_path,
+            adapter_dir=adapter_dir,
+        )

--- a/justatom/training/module.py
+++ b/justatom/training/module.py
@@ -296,8 +296,27 @@ class ContrastiveTrainingModule(L.LightningModule):
         self.objective.kernel.clamp_temperature_()
 
     def save_deployable_encoder(self, destination: Path) -> Path:
+        if self.config.model.lora.enabled:
+            peft_model = self._lora_model()
+            self.encoder.to("cpu")
+            self.encoder.model.model = peft_model.merge_and_unload(safe_merge=True)
         destination.mkdir(parents=True, exist_ok=True)
         self.encoder.save(str(destination))
+        return destination
+
+    def _lora_model(self):
+        from peft import PeftModel
+
+        model = getattr(getattr(self.encoder, "model", None), "model", None)
+        if not isinstance(model, PeftModel):
+            raise RuntimeError("LoRA is enabled, but the encoder does not contain a PEFT model")
+        return model
+
+    def save_lora_adapter(self, destination: Path) -> Path | None:
+        if not self.config.model.lora.enabled:
+            return None
+        destination.mkdir(parents=True, exist_ok=True)
+        self._lora_model().save_pretrained(str(destination), safe_serialization=True)
         return destination
 
     def save_research_checkpoint(self, destination: Path) -> Path | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ torch = [
   "torch==2.8.0",
   "pytorch-lightning==2.2.1",
   "torchmetrics==1.3.2",
-  "transformers>=4.44,<6",
+  "transformers>=4.51,<6",
+  "peft>=0.14,<1",
 ]
 serve = [
   "quart==0.19.6",
@@ -38,7 +39,7 @@ serve = [
 embedder = [
   "quart==0.19.6",
   "hypercorn>=0.17,<1",
-  "transformers>=4.44,<6",
+  "transformers>=4.51,<6",
   "pytorch-lightning==2.2.1",
   "torchmetrics==1.3.2",
   "setuptools<81",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ scikit-learn
 # Metrics or logging related
 seqeval==1.2.2
 # huggingface repository
-transformers
+transformers>=4.51,<6
+peft>=0.14,<1
 # accessing dictionary elements with dot notation
 dotmap==1.3.30
 # Clustering via BERTopic

--- a/tests/test_lora_training.py
+++ b/tests/test_lora_training.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from justatom.training.config import LoraAdapterConfig, RuntimeConfig, TrainingMethod
+from justatom.training.job import apply_lora_adapter, resolve_training_precision
+from justatom.training.methods import canonical_method_config
+from justatom.training.module import ContrastiveTrainingModule
+
+
+def test_apply_lora_adapter_uses_feature_extraction_and_generic_all_linear(monkeypatch):
+    captured = {}
+    backbone = object()
+    language_model = SimpleNamespace(model=backbone)
+
+    class FakeLoraConfig:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("peft.LoraConfig", FakeLoraConfig)
+    monkeypatch.setattr("peft.TaskType", SimpleNamespace(FEATURE_EXTRACTION="feature-extraction"))
+    monkeypatch.setattr("peft.get_peft_model", lambda model, config: (model, config))
+
+    result = apply_lora_adapter(language_model, LoraAdapterConfig(enabled=True))
+
+    assert result is language_model
+    assert result.model[0] is backbone
+    assert captured == {
+        "task_type": "feature-extraction",
+        "inference_mode": False,
+        "r": 16,
+        "lora_alpha": 32,
+        "lora_dropout": 0.0,
+        "target_modules": "all-linear",
+        "use_rslora": True,
+        "bias": "none",
+    }
+
+
+def test_apply_lora_adapter_preserves_disabled_encoder():
+    language_model = SimpleNamespace(model=object())
+
+    assert apply_lora_adapter(language_model, LoraAdapterConfig()) is language_model
+
+
+@pytest.mark.parametrize("accelerator", ["cpu", "mps"])
+def test_auto_precision_keeps_cpu_and_mps_in_float32(accelerator):
+    assert resolve_training_precision(RuntimeConfig(accelerator=accelerator)) == "32-true"
+
+
+def test_auto_precision_prefers_bfloat16_on_supported_cuda(monkeypatch):
+    monkeypatch.setattr("torch.cuda.is_bf16_supported", lambda: True)
+
+    assert resolve_training_precision(RuntimeConfig(accelerator="cuda")) == "bf16-mixed"
+
+
+def test_explicit_precision_is_preserved():
+    runtime = RuntimeConfig(accelerator="mps", precision="16-mixed")
+
+    assert resolve_training_precision(runtime) == "16-mixed"
+
+
+def test_lora_can_be_combined_with_atomic_method():
+    config = canonical_method_config(TrainingMethod.ATOMIC)
+    config = replace(config, model=replace(config.model, lora=LoraAdapterConfig(enabled=True)))
+
+    assert config.alpha_gate.enabled
+    assert config.memory_bank.enabled
+    assert config.model.lora.enabled
+
+
+def test_qwen3_lora_all_linear_has_trainable_adapter_gradients():
+    import torch
+    from peft import PeftModel
+    from transformers import Qwen3Config, Qwen3Model
+
+    from justatom.modeling.prime import Qwen3EmbeddingModel
+
+    backbone = Qwen3Model(
+        Qwen3Config(
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=8,
+        )
+    )
+    language_model = Qwen3EmbeddingModel(backbone)
+    apply_lora_adapter(language_model, LoraAdapterConfig(enabled=True, rank=4, alpha=8))
+
+    assert isinstance(language_model.model, PeftModel)
+    trainable = [parameter for parameter in language_model.parameters() if parameter.requires_grad]
+    assert trainable
+
+    input_ids = torch.randint(0, 64, (2, 8))
+    attention_mask = torch.ones_like(input_ids)
+    query, positive = language_model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pos_input_ids=input_ids,
+        pos_attention_mask=attention_mask,
+    )
+    (query - positive.roll(1, 0)).square().mean().backward()
+
+    assert any(parameter.grad is not None for parameter in trainable)
+
+
+def test_adapter_is_saved_before_encoder_is_merged(monkeypatch, tmp_path):
+    events = []
+
+    class FakePeftModel:
+        def save_pretrained(self, destination, *, safe_serialization):
+            events.append(("adapter", safe_serialization))
+
+        def merge_and_unload(self, *, safe_merge):
+            events.append(("merge", safe_merge))
+            return "merged-backbone"
+
+    class FakeEncoder:
+        def __init__(self):
+            self.model = SimpleNamespace(model=FakePeftModel())
+
+        def to(self, device):
+            events.append(("device", device))
+
+        def save(self, destination):
+            events.append(("encoder", self.model.model))
+
+    class Harness:
+        _lora_model = ContrastiveTrainingModule._lora_model
+        save_lora_adapter = ContrastiveTrainingModule.save_lora_adapter
+        save_deployable_encoder = ContrastiveTrainingModule.save_deployable_encoder
+
+        def __init__(self):
+            config = canonical_method_config(TrainingMethod.VANILLA)
+            self.config = replace(config, model=replace(config.model, lora=LoraAdapterConfig(enabled=True)))
+            self.encoder = FakeEncoder()
+
+    monkeypatch.setattr("peft.PeftModel", FakePeftModel)
+    module = Harness()
+
+    assert module.save_lora_adapter(tmp_path / "adapter") == tmp_path / "adapter"
+    assert module.save_deployable_encoder(tmp_path / "encoder") == tmp_path / "encoder"
+    assert events == [
+        ("adapter", True),
+        ("device", "cpu"),
+        ("merge", True),
+        ("encoder", "merged-backbone"),
+    ]

--- a/tests/test_processor_prefix.py
+++ b/tests/test_processor_prefix.py
@@ -1,0 +1,9 @@
+from justatom.processing.mask import IProcessor
+
+
+def test_empty_prefix_does_not_add_leading_whitespace():
+    assert IProcessor.do_prefix(None, "  passage  ", "") == "passage"
+
+
+def test_non_empty_prefix_has_one_separator():
+    assert IProcessor.do_prefix(None, "  passage  ", "  query:  ") == "query: passage"

--- a/tests/test_runtime_extras.py
+++ b/tests/test_runtime_extras.py
@@ -89,6 +89,14 @@ def test_embedder_extra_has_local_runner_dependencies_without_torch_wheel():
     assert not _contains_requirement(embedder, "torch")
 
 
+def test_torch_extra_has_peft_and_qwen3_compatible_transformers():
+    torch_extra = _extras()["torch"]
+    transformers = next(Requirement(item) for item in torch_extra if Requirement(item).name == "transformers")
+
+    assert _contains_requirement(torch_extra, "peft")
+    assert "4.51" in str(transformers.specifier)
+
+
 def test_clustering_extra_owns_bertopic_and_umap_dependencies():
     clustering = _extras()["clustering"]
 

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -98,3 +98,50 @@ def test_dataset_loader_options_are_typed_and_round_trippable():
 def test_dataset_lazy_must_be_boolean():
     with pytest.raises(ValueError, match=r"dataset\.lazy"):
         parse_train_config({"method": "vanilla", "dataset": {"lazy": "yes"}})
+
+
+def test_lora_config_is_model_agnostic_and_round_trippable():
+    config = parse_train_config(
+        {
+            "method": "atomic",
+            "model": {
+                "name_or_path": "intfloat/multilingual-e5-small",
+                "lora": {
+                    "enabled": True,
+                    "rank": 8,
+                    "alpha": 16,
+                    "dropout": 0.05,
+                    "target_modules": ["query", "value"],
+                    "use_rslora": False,
+                },
+            },
+        }
+    )
+
+    assert config.model.lora.enabled is True
+    assert config.model.lora.target_modules == ("query", "value")
+    assert parse_train_config(train_config_to_dict(config)) == config
+
+
+def test_lora_rejects_non_hugging_face_pfbert():
+    with pytest.raises(ValueError, match=r"pfbert is not supported"):
+        parse_train_config(
+            {
+                "method": "vanilla",
+                "model": {
+                    "name_or_path": "justatom/pfbert",
+                    "lora": {"enabled": True},
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize("target_modules", [[], [""], 7])
+def test_lora_rejects_invalid_target_modules(target_modules):
+    with pytest.raises(ValueError, match=r"model\.lora\.target_modules"):
+        parse_train_config(
+            {
+                "method": "vanilla",
+                "model": {"lora": {"enabled": True, "target_modules": target_modules}},
+            }
+        )

--- a/tests/test_training_job.py
+++ b/tests/test_training_job.py
@@ -29,6 +29,7 @@ def test_artifact_directories_are_distinct(tmp_path: Path):
     paths = artifact_paths(tmp_path)
 
     assert paths.deployable_encoder == tmp_path / "encoder"
+    assert paths.adapter == tmp_path / "adapter"
     assert paths.research_checkpoint == tmp_path / "research" / "checkpoint.pt"
     assert paths.manifest == tmp_path / "run_manifest.yaml"
 
@@ -49,6 +50,10 @@ def test_training_job_writes_manifest_before_fit_and_returns_artifacts(tmp_path:
             events.append("encoder")
             destination.mkdir(parents=True)
             return destination
+
+        def save_lora_adapter(self, destination):
+            events.append("adapter")
+            return None
 
         def save_research_checkpoint(self, destination):
             events.append("checkpoint")
@@ -71,6 +76,7 @@ def test_training_job_writes_manifest_before_fit_and_returns_artifacts(tmp_path:
 
     result = job.run()
 
-    assert events == ["fit", "encoder", "checkpoint"]
+    assert events == ["fit", "checkpoint", "adapter", "encoder"]
     assert result.encoder_dir == tmp_path / "encoder"
     assert result.research_checkpoint == tmp_path / "research" / "checkpoint.pt"
+    assert result.adapter_dir is None


### PR DESCRIPTION
## What
- add model-level LoRA configuration shared by vanilla, atom_gate, and atomic
- wrap supported Hugging Face encoders with PEFT feature-extraction adapters using generic all-linear targets
- save a standalone adapter and research checkpoint before safe-merging a deployable encoder
- resolve portable CUDA/MPS/CPU precision and optional gradient checkpointing
- document a Qwen3-Embedding-0.6B setup and keep pfbert out of scope

## Why
LoRA should change which encoder parameters are optimized without creating another training method or coupling atom_gate and the memory bank to a specific model family. The same config now applies to Qwen3, E5, BGE, and mBERT wrappers.

## Impact
Full fine-tuning remains the default because LoRA is disabled unless explicitly configured. LoRA runs use ordinary Hugging Face PEFT only: no Unsloth, quantization, or CUDA-only adapter path. CUDA auto-selects BF16/FP16 mixed precision; MPS and CPU default to FP32. Deployment continues to load a normal merged encoder without PEFT.

## Root cause
The training loader always exposed the full Hugging Face backbone to the optimizer and the artifact flow only knew about a single deployable encoder plus a research checkpoint. Runtime precision was also delegated entirely to Lightning, so there was no explicit cross-platform policy.

## Checks
- `python -m pytest -q` — 556 passed
- real tiny Qwen3 and E5/BERT PEFT forward/backward smoke
- Black 24.10.0 and isort 5.13.2 checks
- pylint 4.0.6 errors-only and mypy 2.3.0 training checks
- `python -m mkdocs build --strict`