### PR TITLE
Allow vanilla LoRA memory-bank ablations

### DIFF
--- a/configs/experiments/qwen3-06b-lora-vanilla-bank.yaml
+++ b/configs/experiments/qwen3-06b-lora-vanilla-bank.yaml
@@ -29,10 +29,11 @@ optimization:
   lr_encoder: 0.00002
   batch_size: 8
   grad_acc_steps: 4
-  epochs: 2
+  epochs: 1
   num_samples: 4096
 
 objective:
+  decoupled: false
   simcse_dropout_weight: 0.0
 
 memory_bank:

--- a/configs/experiments/qwen3-06b-lora-vanilla-bank.yaml
+++ b/configs/experiments/qwen3-06b-lora-vanilla-bank.yaml
@@ -30,7 +30,7 @@ optimization:
   batch_size: 8
   grad_acc_steps: 4
   epochs: 1
-  num_samples: 4096
+  num_samples: 3000
 
 objective:
   decoupled: false
@@ -40,11 +40,11 @@ memory_bank:
   enabled: true
   size: 512
   warmup_steps: 50
-  mining: mixed
-  hard_negatives: 4
+  mining: random
+  hard_negatives: 0
   random_negatives: 12
-  hard_warmup_steps: 120
-  hard_ramp_steps: 200
+  hard_warmup_steps: 0
+  hard_ramp_steps: 1
   adaptive:
     enabled: false
   margin:

--- a/configs/experiments/qwen3-06b-lora-vanilla-bank.yaml
+++ b/configs/experiments/qwen3-06b-lora-vanilla-bank.yaml
@@ -1,0 +1,57 @@
+method: vanilla
+
+experiment:
+  role: ablation
+  seed: 42
+
+model:
+  name_or_path: Qwen/Qwen3-Embedding-0.6B
+  query_prefix: |-
+    Instruct: Given a web search query, retrieve relevant passages that answer the query
+    Query:
+  content_prefix: ""
+  max_query_seq_len: 128
+  max_seq_len: 512
+  lora:
+    enabled: true
+    rank: 16
+    alpha: 32
+    dropout: 0.05
+    target_modules: all-linear
+    use_rslora: true
+    bias: none
+
+dataset:
+  id: miracl-ru
+  limit: 10000
+
+optimization:
+  lr_encoder: 0.00002
+  batch_size: 8
+  grad_acc_steps: 4
+  epochs: 2
+  num_samples: 4096
+
+objective:
+  simcse_dropout_weight: 0.0
+
+memory_bank:
+  enabled: true
+  size: 512
+  warmup_steps: 50
+  mining: mixed
+  hard_negatives: 4
+  random_negatives: 12
+  hard_warmup_steps: 120
+  hard_ramp_steps: 200
+  adaptive:
+    enabled: false
+  margin:
+    mode: "off"
+    regularization_weight: 0.0
+
+runtime:
+  accelerator: auto
+  devices: 1
+  precision: auto
+  gradient_checkpointing: true

--- a/docs/training.md
+++ b/docs/training.md
@@ -81,6 +81,21 @@ python -m justatom.api.train \
   --memory-bank.margin.mode constant
 ```
 
+A plain InfoNCE control with detached bank negatives keeps the `vanilla`
+method identity but must also be labeled as an ablation. It does not construct
+an alpha gate or query-margin head:
+
+```bash
+python -m justatom.api.train \
+  --config configs/train.yaml \
+  --method vanilla \
+  --experiment.role ablation \
+  --memory-bank.enabled true \
+  --memory-bank.size 512 \
+  --memory-bank.adaptive.enabled false \
+  --memory-bank.margin.mode off
+```
+
 ## Commands
 
 Train one method:
@@ -149,7 +164,7 @@ model:
     bias: none
 
 optimization:
-  lr_encoder: 0.0002
+  lr_encoder: 0.00002
 
 runtime:
   accelerator: auto
@@ -163,6 +178,10 @@ supports it and otherwise FP16. MPS and CPU default to FP32 for compatibility;
 `16-mixed` can be selected explicitly on a supported Mac. Gradient
 checkpointing is independent of LoRA and can be enabled when sequence length
 or batch size needs more memory.
+
+The reproducible Qwen3 0.6B vanilla-plus-bank control is available at
+`configs/experiments/qwen3-06b-lora-vanilla-bank.yaml`. Override `dataset.id`
+and `artifacts.save_dir` on the command line to reuse the recipe.
 
 ## Artifacts
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -91,8 +91,12 @@ python -m justatom.api.train \
   --method vanilla \
   --experiment.role ablation \
   --objective.decoupled false \
+  --optimization.epochs 1 \
+  --optimization.num-samples 3000 \
   --memory-bank.enabled true \
   --memory-bank.size 512 \
+  --memory-bank.mining random \
+  --memory-bank.random-negatives 12 \
   --memory-bank.adaptive.enabled false \
   --memory-bank.margin.mode off
 ```
@@ -182,8 +186,9 @@ or batch size needs more memory.
 
 The reproducible Qwen3 0.6B vanilla-plus-bank control is available at
 `configs/experiments/qwen3-06b-lora-vanilla-bank.yaml`. It uses standard
-coupled InfoNCE and a single epoch. Override `dataset.id` and
-`artifacts.save_dir` on the command line to reuse the recipe.
+coupled InfoNCE, 3,000 sampled pairs, one epoch, and 12 random detached bank
+negatives per query. Override `dataset.id` and `artifacts.save_dir` on the
+command line to reuse the recipe.
 
 ## Artifacts
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -90,6 +90,7 @@ python -m justatom.api.train \
   --config configs/train.yaml \
   --method vanilla \
   --experiment.role ablation \
+  --objective.decoupled false \
   --memory-bank.enabled true \
   --memory-bank.size 512 \
   --memory-bank.adaptive.enabled false \
@@ -180,8 +181,9 @@ checkpointing is independent of LoRA and can be enabled when sequence length
 or batch size needs more memory.
 
 The reproducible Qwen3 0.6B vanilla-plus-bank control is available at
-`configs/experiments/qwen3-06b-lora-vanilla-bank.yaml`. Override `dataset.id`
-and `artifacts.save_dir` on the command line to reuse the recipe.
+`configs/experiments/qwen3-06b-lora-vanilla-bank.yaml`. It uses standard
+coupled InfoNCE and a single epoch. Override `dataset.id` and
+`artifacts.save_dir` on the command line to reuse the recipe.
 
 ## Artifacts
 

--- a/justatom/training/methods.py
+++ b/justatom/training/methods.py
@@ -67,7 +67,12 @@ def resolve_method(config: TrainConfig) -> TrainConfig:
         if gate.enabled:
             raise ValueError("vanilla does not permit alpha_gate.enabled")
         if bank.enabled:
-            raise ValueError("vanilla does not permit memory_bank.enabled")
+            if role is not ExperimentRole.ABLATION:
+                raise ValueError("canonical vanilla does not permit memory_bank.enabled; use experiment.role=ablation")
+            if bank.size <= 0:
+                raise ValueError("vanilla bank ablation requires memory_bank.size > 0")
+            if bank.margin.mode is MarginMode.QUERY and not bank.adaptive.enabled:
+                raise ValueError("memory_bank.margin.mode=query requires memory_bank.adaptive.enabled=true")
         return config
 
     if not gate.enabled:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -45,6 +45,8 @@ def test_qwen_lora_vanilla_bank_recipe_resolves():
     assert config.experiment.role.value == "ablation"
     assert config.model.lora.enabled
     assert config.optimization.lr_encoder == pytest.approx(2e-5)
+    assert config.optimization.epochs == 1
+    assert not config.objective.decoupled
     assert config.memory_bank.enabled
     assert not config.memory_bank.adaptive.enabled
     assert config.memory_bank.margin.mode.value == "off"

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -46,7 +46,11 @@ def test_qwen_lora_vanilla_bank_recipe_resolves():
     assert config.model.lora.enabled
     assert config.optimization.lr_encoder == pytest.approx(2e-5)
     assert config.optimization.epochs == 1
+    assert config.optimization.num_samples == 3000
     assert not config.objective.decoupled
     assert config.memory_bank.enabled
+    assert config.memory_bank.mining == "random"
+    assert config.memory_bank.hard_negatives == 0
+    assert config.memory_bank.random_negatives == 12
     assert not config.memory_bank.adaptive.enabled
     assert config.memory_bank.margin.mode.value == "off"

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -34,3 +34,17 @@ def test_resolve_train_config_applies_dataset_preset_and_method_profile():
     assert config.dataset.name_or_path == ".data/polaroids.ai.data.json"
     assert config.dataset.lazy is False
     assert config.memory_bank.enabled
+
+
+def test_qwen_lora_vanilla_bank_recipe_resolves():
+    config = train.resolve_train_config(
+        config_path="configs/experiments/qwen3-06b-lora-vanilla-bank.yaml",
+    )
+
+    assert config.method.value == "vanilla"
+    assert config.experiment.role.value == "ablation"
+    assert config.model.lora.enabled
+    assert config.optimization.lr_encoder == pytest.approx(2e-5)
+    assert config.memory_bank.enabled
+    assert not config.memory_bank.adaptive.enabled
+    assert config.memory_bank.margin.mode.value == "off"

--- a/tests/test_training_methods.py
+++ b/tests/test_training_methods.py
@@ -59,3 +59,28 @@ def test_vanilla_rejects_alpha_even_for_ablation():
 
     with pytest.raises(ValueError, match="vanilla.*alpha_gate"):
         resolve_method(invalid)
+
+
+def test_vanilla_memory_bank_requires_ablation_role():
+    vanilla = canonical_method_config(TrainingMethod.VANILLA)
+    atomic = canonical_method_config(TrainingMethod.ATOMIC)
+    bank = replace(
+        atomic.memory_bank,
+        adaptive=replace(atomic.memory_bank.adaptive, enabled=False),
+        margin=replace(atomic.memory_bank.margin, mode=MarginMode.OFF, regularization_weight=0.0),
+    )
+
+    with pytest.raises(ValueError, match="canonical vanilla.*experiment.role=ablation"):
+        resolve_method(replace(vanilla, memory_bank=bank))
+
+    ablation = replace(
+        vanilla,
+        experiment=ExperimentConfig(role=ExperimentRole.ABLATION, seed=42),
+        memory_bank=bank,
+    )
+    resolved = resolve_method(ablation)
+
+    assert resolved.memory_bank.enabled
+    assert resolved.memory_bank.size == 512
+    assert not resolved.memory_bank.adaptive.enabled
+    assert resolved.memory_bank.margin.mode is MarginMode.OFF

--- a/tests/test_training_module.py
+++ b/tests/test_training_module.py
@@ -9,7 +9,7 @@ from torch import nn
 from torch.utils.data import DataLoader
 
 from justatom.training.alpha_gate import QueryAlphaGate
-from justatom.training.config import TrainingMethod
+from justatom.training.config import ExperimentConfig, ExperimentRole, MarginMode, TrainingMethod
 from justatom.training.methods import canonical_method_config
 from justatom.training.module import ContrastiveTrainingModule
 from justatom.training.objective import ObjectiveOutput
@@ -80,6 +80,26 @@ def test_module_constructs_only_components_required_by_method():
     assert vanilla.alpha_gate is None and vanilla.memory_bank is None and vanilla.margin_head is None
     assert isinstance(gate.alpha_gate, QueryAlphaGate) and gate.memory_bank is None
     assert atomic.alpha_gate is not None and atomic.memory_bank is not None and atomic.margin_head is not None
+
+
+def test_vanilla_bank_ablation_constructs_bank_without_gate_or_margin_head():
+    vanilla = canonical_method_config(TrainingMethod.VANILLA)
+    atomic = canonical_method_config(TrainingMethod.ATOMIC)
+    config = replace(
+        vanilla,
+        experiment=ExperimentConfig(role=ExperimentRole.ABLATION, seed=42),
+        memory_bank=replace(
+            atomic.memory_bank,
+            adaptive=replace(atomic.memory_bank.adaptive, enabled=False),
+            margin=replace(atomic.memory_bank.margin, mode=MarginMode.OFF, regularization_weight=0.0),
+        ),
+    )
+
+    module = ContrastiveTrainingModule.build(TinyEncoder(), config)
+
+    assert module.alpha_gate is None
+    assert module.memory_bank is not None
+    assert module.margin_head is None
 
 
 def test_optimizer_contains_encoder_temperature_alpha_and_margin_parameters_once():


### PR DESCRIPTION
## Summary

- allow a detached memory bank with `method: vanilla` only when `experiment.role: ablation`; canonical vanilla remains strict
- add a reproducible Qwen3-Embedding-0.6B LoRA + bank recipe using the best low-LR setup
- document the control and cover method resolution, module construction, and recipe loading

## Experiment

MIRACL RU held-out dev-256, 256 candidates, seed 42, 4096 train samples, 2 epochs, LoRA r16/alpha32/dropout0.05/all-linear/rsLoRA, encoder LR 2e-5.

| Variant | Hit@1 | MRR | Recall@10 | Mean rank |
| --- | ---: | ---: | ---: | ---: |
| Base Qwen3-Embedding-0.6B | 0.984375 | 0.992188 | 1.000000 | 1.015625 |
| Vanilla LoRA, no bank | 0.886719 | 0.919839 | 0.972656 | 2.003906 |
| Vanilla LoRA + bank | 0.921875 | 0.944622 | 0.992188 | 1.382812 |
| Previous best ATOMIC-LoRA | 0.921875 | 0.945545 | 0.980469 | 1.578125 |

The bank improves matched vanilla LoRA by 3.52 pp Hit@1 and 0.0248 MRR, but it does not recover the base model quality.

## Validation

- `pytest -q` — 559 passed
- 1024 training batches / 256 optimizer steps on RTX 5090 Laptop, BF16
- bank warmup and mixed mining verified from telemetry: 0 -> 12 random -> 3 hard + 12 random by the final step
- adapter: 392 finite tensors; merged encoder: finite normalized 1024-d embeddings
