### PR TITLE
fix: PyTorch requirements install CPU-only version, even if CUDA is available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 
 [project.optional-dependencies]
 torch = [
-  "torch==2.8.0",
+  "torch>=2.8.0",
   "pytorch-lightning==2.2.1",
   "torchmetrics==1.3.2",
   "transformers>=4.51,<6",


### PR DESCRIPTION
Closes #14