### PR TITLE
Add E5 LoRA InfoNCE recipe

### DIFF
--- a/configs/experiments/e5-small-lora-infonce.yaml
+++ b/configs/experiments/e5-small-lora-infonce.yaml
@@ -1,0 +1,44 @@
+method: vanilla
+
+experiment:
+  role: ablation
+  seed: 42
+
+model:
+  name_or_path: intfloat/multilingual-e5-small
+  query_prefix: "query:"
+  content_prefix: "passage:"
+  max_query_seq_len: 128
+  max_seq_len: 512
+  lora:
+    enabled: true
+    rank: 16
+    alpha: 32
+    dropout: 0.05
+    target_modules: all-linear
+    use_rslora: true
+    bias: none
+
+dataset:
+  id: justatom
+
+optimization:
+  lr_encoder: 0.00002
+  batch_size: 8
+  grad_acc_steps: 4
+  epochs: 1
+  num_samples: 3000
+
+objective:
+  decoupled: false
+  simcse_dropout_weight: 0.0
+
+memory_bank:
+  enabled: false
+  size: 0
+
+runtime:
+  accelerator: auto
+  devices: 1
+  precision: auto
+  gradient_checkpointing: true

--- a/docs/training.md
+++ b/docs/training.md
@@ -190,6 +190,11 @@ coupled InfoNCE, 3,000 sampled pairs, one epoch, and 12 random detached bank
 negatives per query. Override `dataset.id` and `artifacts.save_dir` on the
 command line to reuse the recipe.
 
+For `intfloat/multilingual-e5-small`, use
+`configs/experiments/e5-small-lora-infonce.yaml`. This one-epoch control keeps
+standard coupled InfoNCE but omits the memory bank. Its `query:` and `passage:`
+prefixes are part of the E5 input contract and must also be used at inference.
+
 ## Artifacts
 
 Every successful training run writes:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -54,3 +54,24 @@ def test_qwen_lora_vanilla_bank_recipe_resolves():
     assert config.memory_bank.random_negatives == 12
     assert not config.memory_bank.adaptive.enabled
     assert config.memory_bank.margin.mode.value == "off"
+
+
+def test_e5_small_lora_infonce_recipe_resolves():
+    config = train.resolve_train_config(
+        config_path="configs/experiments/e5-small-lora-infonce.yaml",
+    )
+
+    assert config.method.value == "vanilla"
+    assert config.experiment.role.value == "ablation"
+    assert config.model.name_or_path == "intfloat/multilingual-e5-small"
+    assert config.model.query_prefix == "query:"
+    assert config.model.content_prefix == "passage:"
+    assert config.model.lora.enabled
+    assert config.model.lora.target_modules == "all-linear"
+    assert config.optimization.lr_encoder == pytest.approx(2e-5)
+    assert config.optimization.batch_size == 8
+    assert config.optimization.grad_acc_steps == 4
+    assert config.optimization.epochs == 1
+    assert config.optimization.num_samples == 3000
+    assert not config.objective.decoupled
+    assert not config.memory_bank.enabled


### PR DESCRIPTION
## What changed

- add a reusable `intfloat/multilingual-e5-small` LoRA recipe
- use E5's required `query:` and `passage:` prefixes
- select one epoch of standard coupled InfoNCE (`decoupled: false`)
- document the model-specific recipe and assert its resolved contract

## Why

The Qwen LoRA recipe is mechanically compatible with E5, but the memory-bank
choice needed a matched evaluation rather than being assumed to transfer.

On the deterministic seed-42 document-disjoint JustAtom split (3,000 training
pairs; 10,824 held-out queries over the full 3,937-document evaluation corpus):

| Variant | Hit@1 | Recall@5 | Recall@10 | MRR | Mean rank |
|---|---:|---:|---:|---:|---:|
| Base E5-small | 39.71% | 64.33% | 73.33% | 0.5108 | 35.31 |
| E5-small LoRA + InfoNCE | **44.60%** | **71.42%** | **80.32%** | **0.5680** | **21.01** |
| E5-small LoRA + InfoNCE + random bank | 41.78% | 69.20% | 78.47% | 0.5415 | 21.32 |

Vanilla LoRA improves Hit@1 by 4.89 percentage points over the base model. The
bank remains above base but loses 2.82 points versus vanilla LoRA, so the
checked-in E5 recipe intentionally leaves it disabled.

## Validation

- real RTX 5090 Laptop BF16 train runs for both LoRA variants
- complete-corpus held-out retrieval evaluation for all three variants
- saved adapter validation: 146 tensors, all finite
- `pytest -q tests/test_train_cli.py tests/test_lora_training.py tests/test_training_methods.py` (`22 passed`)
