### PR TITLE
Protect ATOMIC memory gradients with orthogonal projection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
           justatom/training/methods.py \
           justatom/training/alpha_gate.py \
           justatom/training/memory_bank.py \
+          justatom/training/gradient_projection.py \
           justatom/training/objective.py \
           justatom/training/sampling.py \
           justatom/training/telemetry.py \

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -51,6 +51,7 @@ optimization:
 objective: {}
 alpha_gate: {}
 memory_bank: {}
+gradient_projection: {}
 
 telemetry:
   backend: csv

--- a/docs/training.md
+++ b/docs/training.md
@@ -2,11 +2,11 @@
 
 Justatom has one production training path and three public methods.
 
-| Method | Objective | Query gate | Memory bank | Query margin |
-| --- | --- | --- | --- | --- |
-| `vanilla` | decoupled InfoNCE | no | no | no |
-| `atom_gate` | InfoNCE plus query-controlled auxiliary pressure | `alpha(q)` | no | no |
-| `atomic` | `atom_gate` plus adaptive bank negatives | `alpha(q)` | yes | `m(q)` |
+| Method | Primary objective | Auxiliary objective | Gradient control |
+| --- | --- | --- | --- |
+| `vanilla` | InfoNCE | none | none |
+| `atom_gate` | InfoNCE | query-controlled SimCSE pressure | learned `alpha(q)` |
+| `atomic` | standard coupled InfoNCE | detached online memory | one-sided orthogonal projection |
 
 ## Objective
 
@@ -34,50 +34,52 @@ When lexical metadata is available, the same gate also controls a pairwise
 semantic/lexical auxiliary term. The gate is training-only; the saved encoder
 has the same inference interface as the source embedding model.
 
-## Adaptive Bank
+## ATOMIC: protected online memory
 
 `atomic` keeps a FIFO queue `B` of detached document embeddings. The bank does
-not retain previous autograd graphs. For each current query:
+not retain previous autograd graphs. Unlike an ordinary memory-bank objective,
+ATOMIC does not place the extra negatives directly into the protected primary
+loss. It decomposes the objective exactly into:
 
 ```text
-g(q_i) = max_j cosine(q_i, b_j) - cosine(q_i, p_i)
-w_h(q_i) = sigmoid((c - g(q_i)) / beta_c)
+L_primary = InfoNCE(Q, P)
+L_memory  = InfoNCE(Q, P, B) - InfoNCE(Q, P)
 ```
 
-Large positive `g(q)` indicates that a bank candidate is closer than the known
-positive and may be a false negative. Its hard-negative contribution is then
-reduced by `w_h(q)`.
-
-The query margin head predicts
+Let `g_p` and `g_m` be their gradients over the trainable parameters. The
+primary gradient is protected. When the memory gradient conflicts with it,
+ATOMIC removes only the opposing component:
 
 ```text
-m_raw(q) = m_0 + s tanh(h_m(q))
-m(q) = clip(m_raw(q), m_min, m_max).
+if dot(g_p, g_m) < 0:
+    g_m <- g_m - dot(g_p, g_m) / ||g_p||^2 * g_p
+
+g_update = g_p + lambda_memory * g_m
 ```
 
-Each selected bank logit receives differentiable soft admission:
+The projected memory component is orthogonal to `g_p`, so it cannot oppose the
+primary descent direction to first order. Aligned memory gradients are retained
+unchanged. Parameters owned only by an optional memory-side head also retain
+their gradients. Projection is training-only and adds no inference components.
 
-```text
-a_ij = sigmoid((S_i+ - m(q_i) - S_ij_bank) / beta_m)
-z_ij_bank = S_ij_bank / tau + log w_h(q_i) + log a_ij.
-```
-
-The bank columns are concatenated with in-batch negative columns inside the
-same log-sum-exp denominator. Gradients flow through current query embeddings,
-temperature, `alpha(q)`, and `m(q)`, but never through stored bank embeddings.
+Gradient accumulation is performed by the ATOMIC manual optimization step so
+each microbatch is projected before its update is accumulated. The same path is
+implemented with ordinary PyTorch operations and works on CUDA, MPS, and CPU.
 
 ## Canonical Profiles
 
 Selecting a method applies its registered defaults before YAML and CLI
-overrides. Canonical `atomic` currently uses a 512-entry mixed bank, 4 hard and
-12 random candidates, adaptive collision weighting, and a query margin centered
-at `0.05`. Structural changes must be labeled as ablations:
+overrides. Canonical `atomic` uses standard coupled InfoNCE, a 512-entry FIFO
+bank, 50 optimizer-step warmup, 12 random candidates per query, and memory
+weight `1.0`. It does not construct the old alpha gate or a query-margin head.
+Structural additions must be labeled as ablations:
 
 ```bash
 python -m justatom.api.train \
   --config configs/train.yaml \
   --method atomic \
   --experiment.role ablation \
+  --memory-bank.adaptive.enabled true \
   --memory-bank.margin.mode constant
 ```
 
@@ -141,8 +143,10 @@ bash scripts/run_benchmark.sh \
 ## LoRA adapters
 
 LoRA is an encoder configuration, so it composes with every training method.
-The objective, query gate, and memory bank do not change; the optimizer simply
-updates PEFT adapter parameters instead of the frozen backbone parameters.
+The objective and memory-gradient projection do not change; the optimizer
+simply updates PEFT adapter parameters instead of the frozen backbone
+parameters. For ATOMIC, projection is therefore applied in adapter-parameter
+space, including the learnable temperature.
 
 The default `all-linear` target is resolved by PEFT from the Hugging Face model
 itself. This keeps the same config usable for Qwen3-Embedding, E5, BGE, and
@@ -198,7 +202,7 @@ Every successful training run writes:
 - `adapter/`: PEFT adapter and its config when LoRA is enabled
 - `research/checkpoint.pt`: complete training state for analysis or continuation
 - `run_manifest.yaml`: resolved method, data, seed, hyperparameters, and Git state
-- `batch_metrics.csv`: losses, retrieval ranks, `alpha(q)`, bank geometry, collision `g(q)`, hard weights, and margin distributions
+- `batch_metrics.csv`: losses, retrieval ranks, bank geometry, gradient cosine, conflict flag, projection coefficient, and gradient norms
 
 The adapter and research checkpoint are saved before LoRA is merged into the
 deployable encoder. Loading `encoder/` therefore does not require PEFT, while

--- a/justatom/training/config.py
+++ b/justatom/training/config.py
@@ -146,6 +146,15 @@ class MemoryBankConfig:
 
 
 @dataclass(frozen=True)
+class GradientProjectionConfig:
+    """One-sided gradient surgery for the ATOMIC memory objective."""
+
+    enabled: bool = False
+    memory_weight: float = 1.0
+    eps: float = 1e-12
+
+
+@dataclass(frozen=True)
 class TelemetryConfig:
     backend: str = "csv"
     metrics_path: str | None = None
@@ -180,6 +189,7 @@ class TrainConfig:
     objective: ObjectiveConfig = field(default_factory=ObjectiveConfig)
     alpha_gate: AlphaGateConfig = field(default_factory=AlphaGateConfig)
     memory_bank: MemoryBankConfig = field(default_factory=MemoryBankConfig)
+    gradient_projection: GradientProjectionConfig = field(default_factory=GradientProjectionConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     artifacts: ArtifactConfig = field(default_factory=ArtifactConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
@@ -383,6 +393,11 @@ def validate_train_config(config: TrainConfig) -> None:
     _require_number(margin.maximum, "memory_bank.margin.maximum", margin.minimum)
     _require_number(margin.admission_beta, "memory_bank.margin.admission_beta", 1e-12)
     _require_number(margin.regularization_weight, "memory_bank.margin.regularization_weight", 0.0)
+
+    projection = config.gradient_projection
+    _require_bool(projection.enabled, "gradient_projection.enabled")
+    _require_number(projection.memory_weight, "gradient_projection.memory_weight", 0.0)
+    _require_number(projection.eps, "gradient_projection.eps", 1e-30)
 
     if config.telemetry.backend not in {"csv", "wandb"}:
         raise ValueError("telemetry.backend must be one of: csv, wandb")

--- a/justatom/training/gradient_projection.py
+++ b/justatom/training/gradient_projection.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+
+GradientList = Sequence[torch.Tensor | None]
+
+
+@dataclass(frozen=True)
+class ProjectionStats:
+    primary_norm: float
+    memory_norm: float
+    projected_memory_norm: float
+    dot: float
+    cosine: float
+    conflict: bool
+    coefficient: float
+
+    def metrics(self) -> dict[str, float]:
+        return {
+            "gradient/primary_norm": self.primary_norm,
+            "gradient/memory_norm": self.memory_norm,
+            "gradient/projected_memory_norm": self.projected_memory_norm,
+            "gradient/dot": self.dot,
+            "gradient/cosine": self.cosine,
+            "gradient/conflict": float(self.conflict),
+            "gradient/projection_coefficient": self.coefficient,
+        }
+
+
+def project_conflicting_gradients(
+    primary: GradientList,
+    memory: GradientList,
+    *,
+    eps: float = 1e-12,
+) -> tuple[list[torch.Tensor | None], ProjectionStats]:
+    """Project a conflicting memory gradient off the protected primary gradient.
+
+    The operation is deliberately asymmetric. ``primary`` is never changed.
+    When their shared-parameter dot product is negative, the component of the
+    memory gradient that opposes the primary gradient is removed. Gradients for
+    memory-only parameters are retained unchanged.
+    """
+    if len(primary) != len(memory):
+        raise ValueError("primary and memory gradient lists must have equal length")
+    if eps <= 0.0:
+        raise ValueError("eps must be positive")
+
+    reference = next(
+        (gradient for gradient in (*primary, *memory) if gradient is not None),
+        None,
+    )
+    if reference is None:
+        zero_stats = ProjectionStats(0.0, 0.0, 0.0, 0.0, 0.0, False, 0.0)
+        return [None for _ in memory], zero_stats
+
+    device = reference.device
+    dot = torch.zeros((), device=device, dtype=torch.float32)
+    primary_sq = torch.zeros_like(dot)
+    memory_sq = torch.zeros_like(dot)
+    for primary_gradient, memory_gradient in zip(primary, memory):
+        if primary_gradient is not None:
+            primary_float = primary_gradient.detach().float()
+            primary_sq = primary_sq + primary_float.square().sum()
+        if memory_gradient is not None:
+            memory_float = memory_gradient.detach().float()
+            memory_sq = memory_sq + memory_float.square().sum()
+        if primary_gradient is not None and memory_gradient is not None:
+            dot = dot + (primary_gradient.detach().float() * memory_gradient.detach().float()).sum()
+
+    conflict = bool(dot.item() < 0.0 and primary_sq.item() > eps)
+    coefficient = dot / primary_sq.clamp_min(eps) if conflict else torch.zeros_like(dot)
+    projected: list[torch.Tensor | None] = []
+    projected_sq = torch.zeros_like(dot)
+    for primary_gradient, memory_gradient in zip(primary, memory):
+        if memory_gradient is None and (not conflict or primary_gradient is None):
+            projected.append(None)
+            continue
+        if memory_gradient is None:
+            assert primary_gradient is not None
+            value = -coefficient.to(dtype=primary_gradient.dtype) * primary_gradient.detach()
+        else:
+            value = memory_gradient.detach().clone()
+            if conflict and primary_gradient is not None:
+                value = value - coefficient.to(dtype=value.dtype) * primary_gradient.detach()
+        projected.append(value)
+        projected_sq = projected_sq + value.float().square().sum()
+
+    primary_norm = primary_sq.sqrt()
+    memory_norm = memory_sq.sqrt()
+    cosine_denominator = (primary_norm * memory_norm).clamp_min(eps)
+    cosine = dot / cosine_denominator if primary_sq.item() > eps and memory_sq.item() > eps else torch.zeros_like(dot)
+    stats = ProjectionStats(
+        primary_norm=float(primary_norm.item()),
+        memory_norm=float(memory_norm.item()),
+        projected_memory_norm=float(projected_sq.sqrt().item()),
+        dot=float(dot.item()),
+        cosine=float(cosine.item()),
+        conflict=conflict,
+        coefficient=float(coefficient.item()),
+    )
+    return projected, stats

--- a/justatom/training/job.py
+++ b/justatom/training/job.py
@@ -16,7 +16,7 @@ from justatom.processing.loader import NamedDataLoader
 from justatom.processing.prime import TrainWithContrastiveProcessor
 from justatom.running.encoders import EncoderRunner
 from justatom.tooling.collections import build_collection_metadata, resolve_artifact_dirname, write_collection_metadata
-from justatom.training.config import LoraAdapterConfig, RuntimeConfig, TrainConfig, train_config_to_dict
+from justatom.training.config import LoraAdapterConfig, RuntimeConfig, TrainConfig, TrainingMethod, train_config_to_dict
 from justatom.training.data import prepare_training_data_from_config
 from justatom.training.methods import resolve_method
 from justatom.training.module import ContrastiveTrainingModule
@@ -243,7 +243,9 @@ def build_lightning_trainer(config: TrainConfig) -> L.Trainer:
         accelerator=config.runtime.accelerator,
         devices=config.runtime.devices,
         precision=resolve_training_precision(config.runtime),
-        accumulate_grad_batches=config.optimization.grad_acc_steps,
+        # ATOMIC performs gradient accumulation inside its manual optimization
+        # step so both objectives can be differentiated and projected first.
+        accumulate_grad_batches=(1 if config.method is TrainingMethod.ATOMIC else config.optimization.grad_acc_steps),
         logger=build_training_logger(config),
         log_every_n_steps=1,
         enable_checkpointing=False,

--- a/justatom/training/methods.py
+++ b/justatom/training/methods.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from dataclasses import replace
 
 from justatom.training.config import (
-    AdaptiveBankConfig,
     AlphaGateConfig,
     ExperimentRole,
-    MarginConfig,
+    GradientProjectionConfig,
     MarginMode,
     MemoryBankConfig,
     ObjectiveConfig,
@@ -29,31 +28,15 @@ def canonical_method_config(method: TrainingMethod | str) -> TrainConfig:
         enabled=True,
         size=512,
         warmup_steps=50,
-        mining="mixed",
-        hard_negatives=4,
+        mining="random",
+        hard_negatives=0,
         random_negatives=12,
-        hard_warmup_steps=120,
-        hard_ramp_steps=200,
-        adaptive=AdaptiveBankConfig(
-            enabled=True,
-            collision_threshold=0.0,
-            collision_beta=0.05,
-        ),
-        margin=MarginConfig(
-            mode=MarginMode.QUERY,
-            base=0.05,
-            scale=0.02,
-            minimum=0.0,
-            maximum=0.15,
-            admission_beta=0.05,
-            regularization_weight=50.0,
-        ),
     )
     return TrainConfig(
         method=method,
-        objective=objective,
-        alpha_gate=alpha_gate,
+        objective=ObjectiveConfig(decoupled=False),
         memory_bank=memory_bank,
+        gradient_projection=GradientProjectionConfig(enabled=True),
     )
 
 
@@ -66,6 +49,8 @@ def resolve_method(config: TrainConfig) -> TrainConfig:
     if method is TrainingMethod.VANILLA:
         if gate.enabled:
             raise ValueError("vanilla does not permit alpha_gate.enabled")
+        if config.gradient_projection.enabled:
+            raise ValueError("vanilla does not permit gradient_projection.enabled")
         if bank.enabled:
             if role is not ExperimentRole.ABLATION:
                 raise ValueError("canonical vanilla does not permit memory_bank.enabled; use experiment.role=ablation")
@@ -75,26 +60,32 @@ def resolve_method(config: TrainConfig) -> TrainConfig:
                 raise ValueError("memory_bank.margin.mode=query requires memory_bank.adaptive.enabled=true")
         return config
 
-    if not gate.enabled:
-        raise ValueError(f"{method.value} requires alpha_gate.enabled=true")
+    if not gate.enabled and method is TrainingMethod.ATOM_GATE:
+        raise ValueError("atom_gate requires alpha_gate.enabled=true")
 
     if method is TrainingMethod.ATOM_GATE:
+        if config.gradient_projection.enabled:
+            raise ValueError("atom_gate does not permit gradient_projection.enabled")
         if bank.enabled:
             raise ValueError("atom_gate does not permit memory_bank.enabled")
         return config
 
+    if gate.enabled:
+        raise ValueError("atomic does not permit alpha_gate.enabled; memory gradients are controlled by projection")
     if not bank.enabled:
         raise ValueError("atomic requires memory_bank.enabled=true")
     if bank.size <= 0:
         raise ValueError("atomic requires memory_bank.size > 0")
+    if not config.gradient_projection.enabled:
+        raise ValueError("atomic requires gradient_projection.enabled=true")
 
     if role is ExperimentRole.CANONICAL:
-        if not bank.adaptive.enabled:
-            raise ValueError(
-                "canonical atomic requires memory_bank.adaptive.enabled=true; use experiment.role=ablation for controls"
-            )
-        if bank.margin.mode is not MarginMode.QUERY:
-            raise ValueError("canonical atomic requires query margin; set experiment.role=ablation for a fixed-margin control")
+        if config.objective.decoupled:
+            raise ValueError("canonical atomic requires standard coupled InfoNCE")
+        if bank.margin.mode is not MarginMode.OFF:
+            raise ValueError("canonical atomic keeps memory margin off; use experiment.role=ablation to enable it")
+        if bank.adaptive.enabled:
+            raise ValueError("canonical atomic keeps adaptive bank weights off; use experiment.role=ablation to enable them")
 
     if bank.margin.mode is MarginMode.QUERY and not bank.adaptive.enabled:
         raise ValueError("memory_bank.margin.mode=query requires memory_bank.adaptive.enabled=true")

--- a/justatom/training/module.py
+++ b/justatom/training/module.py
@@ -11,6 +11,7 @@ from torch import nn
 from justatom.logging.io import CSVLogger
 from justatom.training.alpha_gate import QueryAlphaGate
 from justatom.training.config import MarginMode, TrainConfig, parse_train_config, train_config_to_dict
+from justatom.training.gradient_projection import project_conflicting_gradients
 from justatom.training.memory_bank import ContrastiveMemoryBank, QueryMarginHead
 from justatom.training.methods import resolve_method
 from justatom.training.objective import ContrastiveObjective, ObjectiveInputs, ObjectiveOutput
@@ -43,6 +44,7 @@ class ContrastiveTrainingModule(L.LightningModule):
         self._last_negative_indices: torch.Tensor | None = None
         self.metrics_path = None if config.telemetry.metrics_path is None else Path(config.telemetry.metrics_path)
         self.metrics_logger = CSVLogger(self.metrics_path) if self.metrics_path is not None else None
+        self.automatic_optimization = not config.gradient_projection.enabled
 
     @classmethod
     def build(
@@ -207,6 +209,10 @@ class ContrastiveTrainingModule(L.LightningModule):
         )
         if not torch.isfinite(output.loss.detach()):
             raise RuntimeError(f"Non-finite loss at step={step}: {output.loss.detach().cpu().item()}")
+        if not torch.isfinite(output.primary_loss.detach()):
+            raise RuntimeError(f"Non-finite primary loss at step={step}: {output.primary_loss.detach().cpu().item()}")
+        if output.memory_loss is not None and not torch.isfinite(output.memory_loss.detach()):
+            raise RuntimeError(f"Non-finite memory loss at step={step}: {output.memory_loss.detach().cpu().item()}")
         with torch.no_grad():
             metrics: dict[str, Any] = dict(output.metrics)
             metrics.update(batch_retrieval_metrics(queries @ positives.T))
@@ -223,10 +229,63 @@ class ContrastiveTrainingModule(L.LightningModule):
             self.memory_bank.enqueue(positives, batch)
         return output
 
-    def training_step(self, batch: dict[str, Any], batch_idx: int) -> torch.Tensor:
-        output = self.compute_training_step(batch, step=int(self.global_step))
-        metrics = resolve_metric_tensors(output.metrics)
-        numeric_metrics = {key: value for key, value in metrics.items() if isinstance(value, (int, float))}
+    @staticmethod
+    def _optimizer_parameters(optimizer: Any) -> list[nn.Parameter]:
+        raw_optimizer = getattr(optimizer, "optimizer", optimizer)
+        return [parameter for group in raw_optimizer.param_groups for parameter in group["params"]]
+
+    @staticmethod
+    def _capture_gradients(parameters: list[nn.Parameter]) -> list[torch.Tensor | None]:
+        return [None if parameter.grad is None else parameter.grad.detach().clone() for parameter in parameters]
+
+    def _projected_optimization_step(self, output: ObjectiveOutput, batch_idx: int) -> dict[str, float]:
+        optimizer = self.optimizers()
+        parameters = self._optimizer_parameters(optimizer)
+        accumulated = self._capture_gradients(parameters)
+        optimizer.zero_grad()
+
+        primary_loss = self.adjust_loss_for_accumulation(output.primary_loss)
+        self.manual_backward(primary_loss, retain_graph=output.memory_loss is not None)
+        primary_gradients = self._capture_gradients(parameters)
+        optimizer.zero_grad()
+
+        if output.memory_loss is None:
+            memory_gradients: list[torch.Tensor | None] = [None for _ in parameters]
+        else:
+            memory_loss = self.adjust_loss_for_accumulation(output.memory_loss)
+            self.manual_backward(memory_loss)
+            memory_gradients = self._capture_gradients(parameters)
+            optimizer.zero_grad()
+
+        projected_memory, stats = project_conflicting_gradients(
+            primary_gradients,
+            memory_gradients,
+            eps=self.config.gradient_projection.eps,
+        )
+        memory_weight = float(self.config.gradient_projection.memory_weight)
+        for parameter, previous, primary, memory in zip(
+            parameters,
+            accumulated,
+            primary_gradients,
+            projected_memory,
+        ):
+            combined = previous
+            if primary is not None:
+                combined = primary if combined is None else combined + primary
+            if memory is not None and memory_weight > 0.0:
+                weighted_memory = memory * memory_weight
+                combined = weighted_memory if combined is None else combined + weighted_memory
+            parameter.grad = combined
+
+        if self.should_step_optimizer(batch_idx):
+            optimizer.step()
+            optimizer.zero_grad()
+            self.objective.kernel.clamp_temperature_()
+        return stats.metrics()
+
+    def _log_training_metrics(self, metrics: dict[str, Any]) -> None:
+        resolved = resolve_metric_tensors(metrics)
+        numeric_metrics = {key: value for key, value in resolved.items() if isinstance(value, (int, float))}
         if self.metrics_logger is not None:
             self.metrics_logger.log_metrics(
                 {
@@ -237,7 +296,14 @@ class ContrastiveTrainingModule(L.LightningModule):
                 }
             )
         self.log_dict(numeric_metrics, on_step=True, on_epoch=False, prog_bar=False)
-        return output.loss
+
+    def training_step(self, batch: dict[str, Any], batch_idx: int) -> torch.Tensor:
+        output = self.compute_training_step(batch, step=int(self.global_step))
+        metrics: dict[str, Any] = dict(output.metrics)
+        if self.config.gradient_projection.enabled:
+            metrics.update(self._projected_optimization_step(output, batch_idx))
+        self._log_training_metrics(metrics)
+        return output.loss.detach() if not self.automatic_optimization else output.loss
 
     def on_train_end(self) -> None:
         if self.metrics_logger is not None:

--- a/justatom/training/objective.py
+++ b/justatom/training/objective.py
@@ -28,7 +28,10 @@ class ObjectiveInputs:
 @dataclass(frozen=True)
 class ObjectiveOutput:
     loss: torch.Tensor
+    primary_loss: torch.Tensor
+    memory_loss: torch.Tensor | None
     main_per_row: torch.Tensor
+    memory_per_row: torch.Tensor | None
     simcse_per_row: torch.Tensor | None
     soft_fn_per_row: torch.Tensor | None
     metrics: dict[str, float | torch.Tensor]
@@ -63,12 +66,27 @@ class ContrastiveObjective(nn.Module):
             inputs.queries,
             inputs.positives,
             reduction="none",
-            memory_negatives=None if memory is None else memory.embeddings,
-            memory_negative_mask=None if memory is None else memory.active_mask,
-            memory_log_weights=None if memory is None else memory.log_weights,
-            memory_margin=inputs.margin,
-            memory_soft_beta=None if margin_config is None else margin_config.admission_beta,
         )
+        memory_per_row = None
+        has_memory = (
+            memory is not None
+            and memory.embeddings is not None
+            and memory.active_mask is not None
+            and bool(memory.active_mask.any().item())
+        )
+        if has_memory:
+            assert memory is not None
+            augmented = self.kernel.info_nce(
+                inputs.queries,
+                inputs.positives,
+                reduction="none",
+                memory_negatives=memory.embeddings,
+                memory_negative_mask=memory.active_mask,
+                memory_log_weights=memory.log_weights,
+                memory_margin=inputs.margin,
+                memory_soft_beta=None if margin_config is None else margin_config.admission_beta,
+            )
+            memory_per_row = augmented - main
 
         simcse = None
         soft_fn = None
@@ -91,13 +109,17 @@ class ContrastiveObjective(nn.Module):
             if alpha.shape != main.shape:
                 raise ValueError(f"alpha must have shape {tuple(main.shape)}, got {tuple(alpha.shape)}")
             per_row = main + (1.0 - alpha) * auxiliary
+        if memory_per_row is not None:
+            per_row = per_row + memory_per_row
         loss = per_row.mean()
+        memory_loss = None if memory_per_row is None else memory_per_row.mean()
 
         active_negatives = 0.0
         if memory is not None and memory.active_mask is not None:
             active_negatives = float(memory.active_mask.float().sum(dim=1).mean().item())
         metrics: dict[str, float | torch.Tensor] = {
             "loss/main": main.detach().mean(),
+            "loss/memory": 0.0 if memory_per_row is None else memory_per_row.detach().mean(),
             "loss/alpha_aux": 0.0 if simcse is None else simcse.detach().mean(),
             "loss/soft_fn": 0.0 if soft_fn is None else soft_fn.detach().mean(),
             "loss/lexical_mix": 0.0,
@@ -130,12 +152,17 @@ class ContrastiveObjective(nn.Module):
         if margin_config is not None and inputs.raw_margin is not None:
             regularization = margin_config.regularization_weight * (inputs.raw_margin - margin_config.base).pow(2).mean()
             loss = loss + regularization
+            memory_loss = regularization if memory_loss is None else memory_loss + regularization
             metrics["loss/memory_margin_regularization"] = regularization.detach()
             metrics["loss/memory_margin_regularization_tensor"] = regularization
 
+        primary_loss = loss if memory_loss is None else loss - memory_loss
         return ObjectiveOutput(
             loss=loss,
+            primary_loss=primary_loss,
+            memory_loss=memory_loss,
             main_per_row=main,
+            memory_per_row=memory_per_row,
             simcse_per_row=simcse,
             soft_fn_per_row=soft_fn,
             metrics=metrics,

--- a/tests/test_gradient_projection.py
+++ b/tests/test_gradient_projection.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from justatom.training.gradient_projection import project_conflicting_gradients
+
+
+def test_conflicting_memory_gradient_is_projected_orthogonally():
+    primary = [torch.tensor([1.0, 0.0])]
+    memory = [torch.tensor([-1.0, 2.0])]
+
+    projected, stats = project_conflicting_gradients(primary, memory)
+
+    assert projected[0] is not None
+    torch.testing.assert_close(projected[0], torch.tensor([0.0, 2.0]))
+    assert torch.dot(primary[0], projected[0]).item() == pytest.approx(0.0, abs=1e-7)
+    assert stats.conflict is True
+    assert stats.cosine < 0.0
+    assert stats.coefficient == pytest.approx(-1.0)
+
+
+def test_aligned_memory_gradient_is_unchanged():
+    primary = [torch.tensor([1.0, 0.0])]
+    memory = [torch.tensor([2.0, 1.0])]
+
+    projected, stats = project_conflicting_gradients(primary, memory)
+
+    torch.testing.assert_close(projected[0], memory[0])
+    assert stats.conflict is False
+    assert stats.coefficient == 0.0
+
+
+def test_memory_only_parameter_gradient_is_retained():
+    primary = [torch.tensor([1.0]), None]
+    memory = [torch.tensor([-1.0]), torch.tensor([3.0])]
+
+    projected, stats = project_conflicting_gradients(primary, memory)
+
+    torch.testing.assert_close(projected[0], torch.zeros(1))
+    torch.testing.assert_close(projected[1], torch.tensor([3.0]))
+    assert stats.conflict is True
+
+
+def test_projection_spans_primary_only_parameters():
+    primary = [torch.tensor([1.0]), torch.tensor([2.0])]
+    memory = [torch.tensor([-1.0]), None]
+
+    projected, stats = project_conflicting_gradients(primary, memory)
+
+    assert projected[0] is not None and projected[1] is not None
+    torch.testing.assert_close(projected[0], torch.tensor([-0.8]))
+    torch.testing.assert_close(projected[1], torch.tensor([0.4]))
+    projected_dot = sum(torch.dot(gp, gm).item() for gp, gm in zip(primary, projected) if gm is not None)
+    assert projected_dot == pytest.approx(0.0, abs=1e-7)
+    assert stats.conflict is True
+
+
+def test_projection_rejects_mismatched_gradient_lists():
+    with pytest.raises(ValueError, match="equal length"):
+        project_conflicting_gradients([torch.ones(1)], [])

--- a/tests/test_lora_training.py
+++ b/tests/test_lora_training.py
@@ -67,8 +67,9 @@ def test_lora_can_be_combined_with_atomic_method():
     config = canonical_method_config(TrainingMethod.ATOMIC)
     config = replace(config, model=replace(config.model, lora=LoraAdapterConfig(enabled=True)))
 
-    assert config.alpha_gate.enabled
+    assert not config.alpha_gate.enabled
     assert config.memory_bank.enabled
+    assert config.gradient_projection.enabled
     assert config.model.lora.enabled
 
 

--- a/tests/test_scenario_configs.py
+++ b/tests/test_scenario_configs.py
@@ -460,7 +460,7 @@ class ScenarioConfigTest(unittest.TestCase):
                     "epochs": 3,
                 },
                 "objective": {"temperature": 0.07},
-                "alpha_gate": {"mix_weight": 0.4},
+                "gradient_projection": {"memory_weight": 0.4},
                 "telemetry": {"backend": "wandb"},
             }
         )
@@ -471,7 +471,7 @@ class ScenarioConfigTest(unittest.TestCase):
         self.assertEqual(config.optimization.grad_acc_steps, 3)
         self.assertEqual(config.optimization.epochs, 3)
         self.assertEqual(config.objective.temperature, 0.07)
-        self.assertEqual(config.alpha_gate.mix_weight, 0.4)
+        self.assertEqual(config.gradient_projection.memory_weight, 0.4)
         self.assertIsNone(config.dataset.split)
         self.assertIsNone(config.dataset.limit)
         self.assertEqual(config.telemetry.backend, "wandb")

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -18,9 +18,11 @@ def test_parse_train_config_builds_typed_atomic_config():
     assert config.method is TrainingMethod.ATOMIC
     assert config.experiment.role is ExperimentRole.CANONICAL
     assert config.experiment.seed == 42
-    assert config.alpha_gate.enabled
+    assert not config.alpha_gate.enabled
     assert config.memory_bank.enabled
-    assert config.memory_bank.margin.mode is MarginMode.QUERY
+    assert config.memory_bank.margin.mode is MarginMode.OFF
+    assert config.gradient_projection.enabled
+    assert not config.objective.decoupled
 
 
 def test_parse_train_config_rejects_unknown_nested_field():
@@ -72,7 +74,8 @@ def test_train_config_serialization_is_plain_and_round_trippable():
 
     assert payload["method"] == "atomic"
     assert payload["experiment"]["role"] == "canonical"
-    assert payload["memory_bank"]["margin"]["mode"] == "query"
+    assert payload["memory_bank"]["margin"]["mode"] == "off"
+    assert payload["gradient_projection"]["enabled"] is True
     assert restored == config
 
 

--- a/tests/test_training_job.py
+++ b/tests/test_training_job.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 
 from justatom.training.config import TrainingMethod
-from justatom.training.job import RunManifest, TrainingJob, artifact_paths, write_run_manifest
+from justatom.training.job import RunManifest, TrainingJob, artifact_paths, build_lightning_trainer, write_run_manifest
 from justatom.training.methods import canonical_method_config
 
 
@@ -22,7 +22,8 @@ def test_manifest_contains_resolved_method_seed_and_git_state(tmp_path: Path):
     assert loaded["experiment"]["seed"] == 42
     assert loaded["git_commit"] == "abc123"
     assert loaded["git_dirty"] is True
-    assert loaded["resolved_config"]["memory_bank"]["margin"]["mode"] == "query"
+    assert loaded["resolved_config"]["memory_bank"]["margin"]["mode"] == "off"
+    assert loaded["resolved_config"]["gradient_projection"]["enabled"] is True
 
 
 def test_artifact_directories_are_distinct(tmp_path: Path):
@@ -32,6 +33,16 @@ def test_artifact_directories_are_distinct(tmp_path: Path):
     assert paths.adapter == tmp_path / "adapter"
     assert paths.research_checkpoint == tmp_path / "research" / "checkpoint.pt"
     assert paths.manifest == tmp_path / "run_manifest.yaml"
+
+
+def test_atomic_trainer_delegates_gradient_accumulation_to_manual_optimization():
+    atomic = canonical_method_config(TrainingMethod.ATOMIC)
+    atomic = replace(atomic, optimization=replace(atomic.optimization, grad_acc_steps=4))
+    vanilla = canonical_method_config(TrainingMethod.VANILLA)
+    vanilla = replace(vanilla, optimization=replace(vanilla.optimization, grad_acc_steps=4))
+
+    assert build_lightning_trainer(atomic).accumulate_grad_batches == 1
+    assert build_lightning_trainer(vanilla).accumulate_grad_batches == 4
 
 
 def test_training_job_writes_manifest_before_fit_and_returns_artifacts(tmp_path: Path):

--- a/tests/test_training_methods.py
+++ b/tests/test_training_methods.py
@@ -15,9 +15,13 @@ def test_canonical_profiles_have_exact_structural_components():
 
     assert not vanilla.alpha_gate.enabled and not vanilla.memory_bank.enabled
     assert gate.alpha_gate.enabled and not gate.memory_bank.enabled
-    assert atomic.alpha_gate.enabled and atomic.memory_bank.enabled
-    assert atomic.memory_bank.adaptive.enabled
-    assert atomic.memory_bank.margin.mode is MarginMode.QUERY
+    assert not atomic.alpha_gate.enabled and atomic.memory_bank.enabled
+    assert atomic.gradient_projection.enabled
+    assert not atomic.objective.decoupled
+    assert atomic.memory_bank.mining == "random"
+    assert atomic.memory_bank.random_negatives == 12
+    assert not atomic.memory_bank.adaptive.enabled
+    assert atomic.memory_bank.margin.mode is MarginMode.OFF
 
 
 def test_canonical_atom_gate_rejects_bank():
@@ -46,6 +50,21 @@ def test_atomic_fixed_margin_requires_ablation_role():
         experiment=ExperimentConfig(role=ExperimentRole.ABLATION, seed=42),
     )
     assert resolve_method(ablation).memory_bank.margin.mode is MarginMode.CONSTANT
+
+
+def test_atomic_requires_projection_and_rejects_alpha_gate():
+    atomic = canonical_method_config(TrainingMethod.ATOMIC)
+    gate = canonical_method_config(TrainingMethod.ATOM_GATE)
+
+    with pytest.raises(ValueError, match="gradient_projection.enabled=true"):
+        resolve_method(
+            replace(
+                atomic,
+                gradient_projection=replace(atomic.gradient_projection, enabled=False),
+            )
+        )
+    with pytest.raises(ValueError, match="does not permit alpha_gate"):
+        resolve_method(replace(atomic, alpha_gate=gate.alpha_gate))
 
 
 def test_vanilla_rejects_alpha_even_for_ablation():

--- a/tests/test_training_module.py
+++ b/tests/test_training_module.py
@@ -63,9 +63,13 @@ def tiny_batch():
 
 
 def finite_output():
+    loss = torch.tensor(1.0, requires_grad=True)
     return ObjectiveOutput(
-        loss=torch.tensor(1.0, requires_grad=True),
+        loss=loss,
+        primary_loss=loss,
+        memory_loss=None,
         main_per_row=torch.ones(2),
+        memory_per_row=None,
         simcse_per_row=None,
         soft_fn_per_row=None,
         metrics={},
@@ -79,7 +83,9 @@ def test_module_constructs_only_components_required_by_method():
 
     assert vanilla.alpha_gate is None and vanilla.memory_bank is None and vanilla.margin_head is None
     assert isinstance(gate.alpha_gate, QueryAlphaGate) and gate.memory_bank is None
-    assert atomic.alpha_gate is not None and atomic.memory_bank is not None and atomic.margin_head is not None
+    assert atomic.alpha_gate is None and atomic.memory_bank is not None and atomic.margin_head is None
+    assert atomic.config.gradient_projection.enabled
+    assert atomic.automatic_optimization is False
 
 
 def test_vanilla_bank_ablation_constructs_bank_without_gate_or_margin_head():
@@ -102,7 +108,7 @@ def test_vanilla_bank_ablation_constructs_bank_without_gate_or_margin_head():
     assert module.margin_head is None
 
 
-def test_optimizer_contains_encoder_temperature_alpha_and_margin_parameters_once():
+def test_optimizer_contains_all_atomic_parameters_once():
     module = ContrastiveTrainingModule.build(TinyEncoder(), canonical_method_config(TrainingMethod.ATOMIC))
 
     optimizer = module.configure_optimizers()
@@ -149,7 +155,10 @@ def test_compute_training_step_rejects_nonfinite_loss(monkeypatch):
     module = ContrastiveTrainingModule.build(TinyEncoder(), canonical_method_config(TrainingMethod.VANILLA))
     bad_output = ObjectiveOutput(
         loss=torch.tensor(float("nan")),
+        primary_loss=torch.tensor(float("nan")),
+        memory_loss=None,
         main_per_row=torch.ones(2),
+        memory_per_row=None,
         simcse_per_row=None,
         soft_fn_per_row=None,
         metrics={},
@@ -202,3 +211,61 @@ def test_lightning_automatic_optimization_keeps_tau_version_valid(tmp_path):
 
     assert trainer.global_step == 1
     assert torch.isfinite(module.objective.kernel.log_tau)
+
+
+def test_lightning_atomic_manual_optimization_steps_with_live_bank(tmp_path):
+    config = canonical_method_config(TrainingMethod.ATOMIC)
+    config = replace(
+        config,
+        memory_bank=replace(config.memory_bank, size=8, warmup_steps=0, random_negatives=1),
+    )
+    module = ContrastiveTrainingModule.build(TinyEncoder(), config)
+    second = {key: value.clone() for key, value in tiny_batch().items()}
+    for key in ("doc_key_id", "content_key_id", "query_key_id"):
+        second[key] += 100
+    trainer = L.Trainer(
+        max_epochs=1,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        default_root_dir=tmp_path,
+    )
+
+    trainer.fit(module, train_dataloaders=DataLoader([tiny_batch(), second], batch_size=None))
+
+    assert trainer.global_step == 2
+    assert module.memory_bank is not None and module.memory_bank.current_size == 4
+    assert torch.isfinite(module.objective.kernel.log_tau)
+
+
+def test_lightning_atomic_handles_gradient_accumulation_and_final_partial_step(tmp_path):
+    config = canonical_method_config(TrainingMethod.ATOMIC)
+    config = replace(
+        config,
+        optimization=replace(config.optimization, grad_acc_steps=2),
+        memory_bank=replace(config.memory_bank, size=8, warmup_steps=0, random_negatives=1),
+    )
+    module = ContrastiveTrainingModule.build(TinyEncoder(), config)
+    batches = []
+    for offset in (0, 100, 200):
+        batch = {key: value.clone() for key, value in tiny_batch().items()}
+        for key in ("doc_key_id", "content_key_id", "query_key_id"):
+            batch[key] += offset
+        batches.append(batch)
+    trainer = L.Trainer(
+        max_epochs=1,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        default_root_dir=tmp_path,
+    )
+
+    trainer.fit(module, train_dataloaders=DataLoader(batches, batch_size=None))
+
+    assert trainer.global_step == 2

--- a/tests/test_training_objective.py
+++ b/tests/test_training_objective.py
@@ -16,6 +16,8 @@ def test_objective_vanilla_has_no_auxiliary_components():
     output = objective(ObjectiveInputs(queries=queries, positives=positives))
 
     assert output.loss.ndim == 0
+    torch.testing.assert_close(output.primary_loss, output.loss)
+    assert output.memory_loss is None
     assert output.simcse_per_row is None
     assert output.metrics["loss/alpha_aux"] == 0.0
     assert output.metrics["loss/memory_margin_regularization"] == 0.0
@@ -104,6 +106,9 @@ def test_objective_atomic_forwards_bank_columns_and_live_margin():
         ),
         margin_config=MarginConfig(mode=MarginMode.QUERY, admission_beta=0.05),
     )
+    assert output.memory_loss is not None
+    assert output.memory_per_row is not None
+    torch.testing.assert_close(output.loss, output.primary_loss + output.memory_loss)
     output.loss.backward()
 
     assert margin.grad is not None and float(margin.grad.abs().sum()) > 0.0


### PR DESCRIPTION
## What changed

- redefine canonical `atomic` as standard coupled InfoNCE plus a detached online-memory auxiliary objective
- decompose the bank contribution exactly as `InfoNCE(Q, P, B) - InfoNCE(Q, P)`
- apply asymmetric gradient surgery: conflicting memory gradients are projected onto the plane orthogonal to the protected primary gradient
- move ATOMIC to Lightning manual optimization so projection composes correctly with mixed precision and gradient accumulation
- record primary/memory losses, gradient cosine, conflict flag, projection coefficient, and gradient norms
- remove the degenerate `alpha_gate`, adaptive weights, and query-margin head from the canonical ATOMIC profile
- document the new method contract and add the projection module to CI type checking

## Why

The former gate minimized `L_main + (1 - alpha) * L_aux` with a non-negative auxiliary loss, so its trivial optimum was `alpha = 1`. Experiments confirmed that collapse. A uniform memory bank also improved long-tail mean rank while degrading top-rank metrics, which indicates useful but sometimes conflicting training signal.

The new ATOMIC formulation treats clean InfoNCE as the protected objective and admits the online-memory gradient only in directions that do not oppose primary descent to first order.

## Impact

Inference artifacts and serving interfaces are unchanged. ATOMIC training now performs two backward passes per microbatch and retains both gradient vectors until projection, trading training time and memory for interference control. LoRA projects in adapter-parameter space; full fine-tuning projects over all trainable parameters. The implementation uses ordinary PyTorch operations on CUDA, MPS, and CPU.

The canonical ATOMIC module graph changed, so legacy ATOMIC research checkpoints containing the old alpha/margin heads are not resumable through the new canonical profile. Previously exported deployable encoders remain usable.

## Validation

- `python -m pytest tests -m "not integration and not network" -q` — 548 passed, 20 deselected
- focused projection/objective/manual-optimization tests — 30 passed
- Black 24.10.0 and isort 5.13.2 checks
- mypy 2.3.0 on the typed training stack
- pylint 4.0.6 `--errors-only`
