### PR TITLE
feat(training): add optional transformers reranker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
           justatom/training/alpha_gate.py \
           justatom/training/memory_bank.py \
           justatom/training/gradient_projection.py \
+          justatom/training/reranker.py \
           justatom/training/objective.py \
           justatom/training/sampling.py \
           justatom/training/telemetry.py \

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -52,6 +52,25 @@ objective: {}
 alpha_gate: {}
 memory_bank: {}
 gradient_projection: {}
+reranker:
+  enabled: false
+  backend: transformers
+  model_name_or_path: Qwen/Qwen3-Reranker-4B
+  revision: 22e683669bc0f0bd69640a1354a6d0aebcfeede5
+  instruction: Given a web search query, retrieve relevant passages that answer the query
+  device: auto
+  dtype: auto
+  local_files_only: true
+  max_length: 512
+  batch_size: 4
+  prefilter_hard_negatives: 32
+  prefilter_random_negatives: 8
+  negatives: 12
+  min_score_gap: 0.1
+  cache:
+    mode: read-write
+    path: .cache/justatom/reranker.sqlite
+    on_miss: score
 
 telemetry:
   backend: csv

--- a/docs/training.md
+++ b/docs/training.md
@@ -66,6 +66,64 @@ Gradient accumulation is performed by the ATOMIC manual optimization step so
 each microbatch is projected before its update is accumulated. The same path is
 implemented with ordinary PyTorch operations and works on CUDA, MPS, and CPU.
 
+### Optional teacher-filtered memory
+
+The projected ATOMIC implementation remains the default and does not require a
+reranker. Setting `reranker.enabled: true` adds a frozen teacher only to memory
+candidate selection; it does not replace InfoNCE, change the projection, or add
+anything to the deployable encoder.
+
+For every query, the student first selects hard and random candidates from the
+FIFO bank. The teacher scores the labelled positive and those candidates. A
+candidate is admitted as a negative only when its score is at least
+`min_score_gap` below the positive score. The final `negatives` entries are the
+safe candidates with the highest student similarity:
+
+```text
+FIFO bank
+  -> student top-32 + 8 random candidates
+  -> frozen reranker false-negative filter
+  -> 12 hardest safe negatives
+  -> memory loss
+  -> one-sided gradient projection
+```
+
+Teacher scoring is online, while scores are stored in a content-addressed
+SQLite cache. The key includes the model revision, instruction, scoring
+template, maximum length, query, and document. A first seed populates the cache;
+later seeds and epochs reuse matching pairs. Use `read-only` with
+`on_miss: error` to make a populated cache a strict reproducibility boundary.
+
+```yaml
+method: atomic
+
+reranker:
+  enabled: true
+  backend: transformers
+  model_name_or_path: Qwen/Qwen3-Reranker-4B
+  revision: 22e683669bc0f0bd69640a1354a6d0aebcfeede5
+  local_files_only: true
+  device: auto
+  dtype: auto
+  max_length: 512
+  batch_size: 4
+  prefilter_hard_negatives: 32
+  prefilter_random_negatives: 8
+  negatives: 12
+  min_score_gap: 0.1
+  cache:
+    mode: read-write  # off | read-write | read-only
+    path: .cache/justatom/reranker.sqlite
+    on_miss: score    # score | error | skip
+```
+
+The Transformers backend and cache are created only when the option is enabled,
+and the model weights are loaded lazily on the first cache miss. With
+`local_files_only: true`, training never downloads the teacher.
+On MPS or a machine that cannot host both models, leave the reranker disabled;
+the original memory selection and projected ATOMIC path are unchanged. A
+service backend can implement the same scoring contract in a future extension.
+
 ## Canonical Profiles
 
 Selecting a method applies its registered defaults before YAML and CLI

--- a/justatom/builtins/configs/train.default.yaml
+++ b/justatom/builtins/configs/train.default.yaml
@@ -51,6 +51,26 @@ optimization:
 objective: {}
 alpha_gate: {}
 memory_bank: {}
+gradient_projection: {}
+reranker:
+  enabled: false
+  backend: transformers
+  model_name_or_path: Qwen/Qwen3-Reranker-4B
+  revision: 22e683669bc0f0bd69640a1354a6d0aebcfeede5
+  instruction: Given a web search query, retrieve relevant passages that answer the query
+  device: auto
+  dtype: auto
+  local_files_only: true
+  max_length: 512
+  batch_size: 4
+  prefilter_hard_negatives: 32
+  prefilter_random_negatives: 8
+  negatives: 12
+  min_score_gap: 0.1
+  cache:
+    mode: read-write
+    path: .cache/justatom/reranker.sqlite
+    on_miss: score
 
 telemetry:
   backend: csv

--- a/justatom/training/config.py
+++ b/justatom/training/config.py
@@ -155,6 +155,36 @@ class GradientProjectionConfig:
 
 
 @dataclass(frozen=True)
+class RerankerCacheConfig:
+    """Persistent score-cache policy for an optional teacher reranker."""
+
+    mode: str = "read-write"
+    path: str = ".cache/justatom/reranker.sqlite"
+    on_miss: str = "score"
+
+
+@dataclass(frozen=True)
+class RerankerConfig:
+    """Optional teacher used to filter memory-bank negatives."""
+
+    enabled: bool = False
+    backend: str = "transformers"
+    model_name_or_path: str = "Qwen/Qwen3-Reranker-4B"
+    revision: str | None = "22e683669bc0f0bd69640a1354a6d0aebcfeede5"
+    instruction: str = "Given a web search query, retrieve relevant passages that answer the query"
+    device: str = "auto"
+    dtype: str = "auto"
+    local_files_only: bool = True
+    max_length: int = 512
+    batch_size: int = 4
+    prefilter_hard_negatives: int = 32
+    prefilter_random_negatives: int = 8
+    negatives: int = 12
+    min_score_gap: float = 0.1
+    cache: RerankerCacheConfig = field(default_factory=RerankerCacheConfig)
+
+
+@dataclass(frozen=True)
 class TelemetryConfig:
     backend: str = "csv"
     metrics_path: str | None = None
@@ -190,6 +220,7 @@ class TrainConfig:
     alpha_gate: AlphaGateConfig = field(default_factory=AlphaGateConfig)
     memory_bank: MemoryBankConfig = field(default_factory=MemoryBankConfig)
     gradient_projection: GradientProjectionConfig = field(default_factory=GradientProjectionConfig)
+    reranker: RerankerConfig = field(default_factory=RerankerConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     artifacts: ArtifactConfig = field(default_factory=ArtifactConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
@@ -398,6 +429,40 @@ def validate_train_config(config: TrainConfig) -> None:
     _require_bool(projection.enabled, "gradient_projection.enabled")
     _require_number(projection.memory_weight, "gradient_projection.memory_weight", 0.0)
     _require_number(projection.eps, "gradient_projection.eps", 1e-30)
+
+    reranker = config.reranker
+    _require_bool(reranker.enabled, "reranker.enabled")
+    if reranker.backend != "transformers":
+        raise ValueError("reranker.backend must be transformers")
+    if not isinstance(reranker.model_name_or_path, str) or not reranker.model_name_or_path:
+        raise ValueError("reranker.model_name_or_path must be a non-empty string")
+    if reranker.revision is not None and (not isinstance(reranker.revision, str) or not reranker.revision):
+        raise ValueError("reranker.revision must be a non-empty string or null")
+    if not isinstance(reranker.instruction, str) or not reranker.instruction:
+        raise ValueError("reranker.instruction must be a non-empty string")
+    if not isinstance(reranker.device, str) or not reranker.device:
+        raise ValueError("reranker.device must be a non-empty string")
+    if reranker.dtype not in {"auto", "float32", "float16", "bfloat16"}:
+        raise ValueError("reranker.dtype must be one of: auto, float32, float16, bfloat16")
+    _require_bool(reranker.local_files_only, "reranker.local_files_only")
+    _require_int(reranker.max_length, "reranker.max_length", 1)
+    _require_int(reranker.batch_size, "reranker.batch_size", 1)
+    _require_int(reranker.prefilter_hard_negatives, "reranker.prefilter_hard_negatives", 0)
+    _require_int(reranker.prefilter_random_negatives, "reranker.prefilter_random_negatives", 0)
+    _require_int(reranker.negatives, "reranker.negatives", 1)
+    _require_number(reranker.min_score_gap, "reranker.min_score_gap", 0.0)
+    if reranker.prefilter_hard_negatives + reranker.prefilter_random_negatives <= 0:
+        raise ValueError("reranker prefilter requires at least one candidate")
+    if reranker.cache.mode not in {"off", "read-write", "read-only"}:
+        raise ValueError("reranker.cache.mode must be one of: off, read-write, read-only")
+    if not isinstance(reranker.cache.path, str) or not reranker.cache.path:
+        raise ValueError("reranker.cache.path must be a non-empty string")
+    if reranker.cache.on_miss not in {"score", "error", "skip"}:
+        raise ValueError("reranker.cache.on_miss must be one of: score, error, skip")
+    if reranker.cache.mode == "read-only" and reranker.cache.on_miss == "score":
+        raise ValueError("reranker.cache.mode=read-only does not permit cache.on_miss=score")
+    if reranker.enabled and not bank.enabled:
+        raise ValueError("reranker.enabled requires memory_bank.enabled=true")
 
     if config.telemetry.backend not in {"csv", "wandb"}:
         raise ValueError("telemetry.backend must be one of: csv, wandb")

--- a/justatom/training/memory_bank.py
+++ b/justatom/training/memory_bank.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Sequence
 
 import torch
 import torch.nn.functional as F
@@ -8,6 +9,7 @@ from loguru import logger
 from torch import nn
 
 from justatom.training.config import MarginConfig, MarginMode, MemoryBankConfig
+from justatom.training.reranker import CachedTextReranker
 from justatom.training.telemetry import scalar_distribution
 
 
@@ -53,7 +55,7 @@ class QueryMarginHead(nn.Module):
 class ContrastiveMemoryBank:
     """Typed FIFO bank of detached document embeddings used as extra negatives."""
 
-    def __init__(self, config: MemoryBankConfig):
+    def __init__(self, config: MemoryBankConfig, *, reranker: CachedTextReranker | None = None):
         if not isinstance(config, MemoryBankConfig):
             raise TypeError("ContrastiveMemoryBank requires MemoryBankConfig")
         if config.mining not in {"all", "random", "hard", "mixed"}:
@@ -62,10 +64,12 @@ class ContrastiveMemoryBank:
             raise ValueError("memory_bank.adaptive.collision_beta must be positive")
 
         self.config = config
+        self.reranker = reranker
         self.embeddings: torch.Tensor | None = None
         self.doc_key_ids: torch.Tensor | None = None
         self.content_key_ids: torch.Tensor | None = None
         self.query_key_ids: torch.Tensor | None = None
+        self.documents: list[str] | None = [] if reranker is not None else None
 
     @property
     def enabled(self) -> bool:
@@ -74,6 +78,10 @@ class ContrastiveMemoryBank:
     @property
     def current_size(self) -> int:
         return 0 if self.embeddings is None else int(self.embeddings.shape[0])
+
+    @property
+    def reranker_enabled(self) -> bool:
+        return self.reranker is not None
 
     def _base_metrics(self) -> dict[str, float | str]:
         return {
@@ -90,14 +98,30 @@ class ContrastiveMemoryBank:
         }
 
     def _noop_selection(self) -> MemorySelection:
+        metrics = self._base_metrics()
+        if self.reranker is not None:
+            metrics.update(self._base_reranker_metrics())
         return MemorySelection(
             embeddings=None,
             active_mask=None,
             log_weights=None,
             collision_g=None,
             hard_weights=None,
-            metrics=self._base_metrics(),
+            metrics=metrics,
         )
+
+    @staticmethod
+    def _base_reranker_metrics() -> dict[str, float]:
+        return {
+            "reranker/candidates_mean": 0.0,
+            "reranker/safe_negatives_mean": 0.0,
+            "reranker/ambiguous_mean": 0.0,
+            "reranker/above_positive_mean": 0.0,
+            "reranker/cache_hits": 0.0,
+            "reranker/cache_misses": 0.0,
+            "reranker/cache_hit_rate": 0.0,
+            "reranker/skipped": 0.0,
+        }
 
     @torch.no_grad()
     def select(
@@ -107,6 +131,8 @@ class ContrastiveMemoryBank:
         query_vectors: torch.Tensor,
         positive_vectors: torch.Tensor,
         step: int,
+        query_texts: Sequence[str] | None = None,
+        positive_texts: Sequence[str] | None = None,
     ) -> MemorySelection:
         if not self.enabled or self.embeddings is None or self.current_size == 0 or int(step) < self.config.warmup_steps:
             return self._noop_selection()
@@ -130,8 +156,24 @@ class ContrastiveMemoryBank:
         random_k = self.config.random_negatives
         hard_active = torch.zeros_like(valid)
         random_active = torch.zeros_like(valid)
+        reranker_metrics: dict[str, float] = {}
 
-        if self.config.mining == "all":
+        if self.reranker is not None:
+            reranker_config = self.reranker.config
+            hard_k = reranker_config.prefilter_hard_negatives
+            random_k = reranker_config.prefilter_random_negatives
+            hard_candidates = self._topk_mask(bank_similarities, valid, hard_k)
+            random_candidates = self._random_mask(valid & ~hard_candidates, random_k)
+            candidate_mask = hard_candidates | random_candidates
+            active, reranker_metrics = self._reranker_selection(
+                candidate_mask=candidate_mask,
+                bank_similarities=bank_similarities,
+                query_texts=query_texts,
+                positive_texts=positive_texts,
+            )
+            hard_active = active & hard_candidates
+            random_active = active & random_candidates
+        elif self.config.mining == "all":
             active = valid.clone()
             hard_k = 0
             random_k = 0
@@ -163,6 +205,7 @@ class ContrastiveMemoryBank:
             hard_k=hard_k,
             random_k=random_k,
         )
+        metrics.update(reranker_metrics)
         return MemorySelection(
             embeddings=embeddings,
             active_mask=active,
@@ -171,6 +214,92 @@ class ContrastiveMemoryBank:
             hard_weights=hard_weights,
             metrics=metrics,
         )
+
+    def _reranker_selection(
+        self,
+        *,
+        candidate_mask: torch.Tensor,
+        bank_similarities: torch.Tensor,
+        query_texts: Sequence[str] | None,
+        positive_texts: Sequence[str] | None,
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        assert self.reranker is not None
+        if query_texts is None or positive_texts is None:
+            raise ValueError("reranker selection requires query_texts and positive_texts")
+        batch_size, bank_size = candidate_mask.shape
+        if len(query_texts) != batch_size or len(positive_texts) != batch_size:
+            raise ValueError("reranker texts must match the query batch size")
+        if self.documents is None or len(self.documents) != bank_size:
+            raise RuntimeError("reranker document metadata is not aligned with memory-bank embeddings")
+
+        pair_queries: list[str] = []
+        pair_documents: list[str] = []
+        row_candidates: list[list[int]] = []
+        for row in range(batch_size):
+            indices = candidate_mask[row].nonzero(as_tuple=False).view(-1).detach().cpu().tolist()
+            row_candidates.append(indices)
+            pair_queries.append(str(query_texts[row]))
+            pair_documents.append(str(positive_texts[row]))
+            pair_queries.extend(str(query_texts[row]) for _ in indices)
+            pair_documents.extend(self.documents[index] for index in indices)
+
+        score_result = self.reranker.score_pairs(pair_queries, pair_documents)
+        active = torch.zeros_like(candidate_mask)
+        positive_scores: list[float] = []
+        candidate_scores: list[float] = []
+        score_gaps: list[float] = []
+        safe_counts: list[int] = []
+        ambiguous_counts: list[int] = []
+        above_positive_counts: list[int] = []
+        offset = 0
+        for row, indices in enumerate(row_candidates):
+            positive_score = score_result.values[offset]
+            offset += 1
+            row_scores = score_result.values[offset : offset + len(indices)]
+            offset += len(indices)
+            if positive_score is None:
+                safe_counts.append(0)
+                ambiguous_counts.append(len(indices))
+                above_positive_counts.append(0)
+                continue
+            positive_scores.append(positive_score)
+            safe_indices: list[int] = []
+            above_positive = 0
+            for bank_index, candidate_score in zip(indices, row_scores):
+                if candidate_score is None:
+                    continue
+                candidate_scores.append(candidate_score)
+                score_gaps.append(positive_score - candidate_score)
+                above_positive += int(candidate_score >= positive_score)
+                if candidate_score <= positive_score - self.reranker.config.min_score_gap:
+                    safe_indices.append(bank_index)
+            safe_counts.append(len(safe_indices))
+            ambiguous_counts.append(len(indices) - len(safe_indices))
+            above_positive_counts.append(above_positive)
+            if safe_indices:
+                safe_tensor = torch.tensor(safe_indices, device=bank_similarities.device, dtype=torch.long)
+                count = min(self.reranker.config.negatives, len(safe_indices))
+                selected = bank_similarities[row, safe_tensor].topk(count).indices
+                active[row, safe_tensor[selected]] = True
+
+        total_cache = score_result.cache_hits + score_result.cache_misses
+        metrics = self._base_reranker_metrics()
+        metrics.update(
+            {
+                "reranker/candidates_mean": float(candidate_mask.float().sum(dim=1).mean().item()),
+                "reranker/safe_negatives_mean": float(sum(safe_counts) / max(batch_size, 1)),
+                "reranker/ambiguous_mean": float(sum(ambiguous_counts) / max(batch_size, 1)),
+                "reranker/above_positive_mean": float(sum(above_positive_counts) / max(batch_size, 1)),
+                "reranker/cache_hits": float(score_result.cache_hits),
+                "reranker/cache_misses": float(score_result.cache_misses),
+                "reranker/cache_hit_rate": float(score_result.cache_hits / total_cache) if total_cache else 0.0,
+                "reranker/skipped": float(score_result.skipped),
+            }
+        )
+        metrics.update(scalar_distribution("reranker/positive_score", torch.tensor(positive_scores)))
+        metrics.update(scalar_distribution("reranker/candidate_score", torch.tensor(candidate_scores)))
+        metrics.update(scalar_distribution("reranker/positive_candidate_gap", torch.tensor(score_gaps)))
+        return active, metrics
 
     def _valid_identity_mask(
         self,
@@ -247,7 +376,13 @@ class ContrastiveMemoryBank:
             metrics.update(scalar_distribution("memory/hard_weight", hard_weights))
         return metrics
 
-    def enqueue(self, vectors: torch.Tensor, batch: dict[str, torch.Tensor]) -> None:
+    def enqueue(
+        self,
+        vectors: torch.Tensor,
+        batch: dict[str, torch.Tensor],
+        *,
+        document_texts: Sequence[str] | None = None,
+    ) -> None:
         if not self.enabled or vectors.numel() == 0:
             return
         vectors = F.normalize(vectors.detach().clone(), p=2, dim=-1, eps=1e-8)
@@ -261,6 +396,15 @@ class ContrastiveMemoryBank:
             vectors.device,
         )
         self.query_key_ids = self._append_ids(self.query_key_ids, batch.get("query_key_id"), vectors.device)
+        if self.reranker is not None:
+            if document_texts is None or len(document_texts) != vectors.shape[0]:
+                raise ValueError("reranker-enabled memory bank requires one document text per vector")
+            assert self.documents is not None
+            self.documents = [*self.documents, *(str(text) for text in document_texts)][-self.config.size :]
+
+    def close(self) -> None:
+        if self.reranker is not None:
+            self.reranker.close()
 
     def _append(self, previous: torch.Tensor | None, current: torch.Tensor) -> torch.Tensor:
         merged = current if previous is None else torch.cat([previous.to(current), current], dim=0)

--- a/justatom/training/module.py
+++ b/justatom/training/module.py
@@ -15,6 +15,7 @@ from justatom.training.gradient_projection import project_conflicting_gradients
 from justatom.training.memory_bank import ContrastiveMemoryBank, QueryMarginHead
 from justatom.training.methods import resolve_method
 from justatom.training.objective import ContrastiveObjective, ObjectiveInputs, ObjectiveOutput
+from justatom.training.reranker import build_reranker
 from justatom.training.sampling import inverse_idf_recall, sample_safe_negative_indices
 from justatom.training.telemetry import batch_retrieval_metrics, resolve_metric_tensors, scalar_distribution
 
@@ -57,7 +58,11 @@ class ContrastiveTrainingModule(L.LightningModule):
         config = resolve_method(config)
         embedding_dim = int(getattr(encoder, "output_dims"))
         alpha_gate = QueryAlphaGate(embedding_dim, config.alpha_gate) if config.alpha_gate.enabled else None
-        memory_bank = ContrastiveMemoryBank(config.memory_bank) if config.memory_bank.enabled else None
+        memory_bank = (
+            ContrastiveMemoryBank(config.memory_bank, reranker=build_reranker(config.reranker))
+            if config.memory_bank.enabled
+            else None
+        )
         margin_head = (
             QueryMarginHead(embedding_dim, config.memory_bank.margin)
             if config.memory_bank.margin.mode is MarginMode.QUERY
@@ -167,10 +172,31 @@ class ContrastiveTrainingModule(L.LightningModule):
             return margin, margin
         return None, None
 
+    def _reranker_texts(self, batch: dict[str, Any]) -> tuple[list[str], list[str]]:
+        queries = batch.get("query_text")
+        documents = batch.get("content_text")
+        if queries is not None and documents is not None:
+            return [str(text) for text in queries], [str(text) for text in documents]
+        tokenizer = getattr(getattr(self.encoder, "processor", None), "tokenizer", None)
+        if tokenizer is None or "input_ids" not in batch or "pos_input_ids" not in batch:
+            raise RuntimeError("reranker requires raw texts or a tokenizer capable of decoding the training batch")
+        query_ids = batch["input_ids"].detach().cpu()
+        document_ids = batch["pos_input_ids"].detach().cpu()
+        decoded_queries = tokenizer.batch_decode(query_ids, skip_special_tokens=True)
+        decoded_documents = tokenizer.batch_decode(document_ids, skip_special_tokens=True)
+        return (
+            [self._remove_text_prefix(text, self.config.model.query_prefix) for text in decoded_queries],
+            [self._remove_text_prefix(text, self.config.model.content_prefix) for text in decoded_documents],
+        )
+
     def compute_training_step(self, batch: dict[str, Any], *, step: int) -> ObjectiveOutput:
         queries, positives = self.encoder.encode_pair(batch)
         alpha = None if self.alpha_gate is None else self.alpha_gate(queries)
         query_alt = self._encode_dropout_query_view(batch) if self.needs_simcse else None
+        query_texts = None
+        positive_texts = None
+        if self.memory_bank is not None and self.memory_bank.reranker_enabled:
+            query_texts, positive_texts = self._reranker_texts(batch)
         selection = (
             None
             if self.memory_bank is None
@@ -179,6 +205,8 @@ class ContrastiveTrainingModule(L.LightningModule):
                 query_vectors=queries,
                 positive_vectors=positives,
                 step=step,
+                query_texts=query_texts,
+                positive_texts=positive_texts,
             )
         )
         raw_margin, margin = self._margin_values(queries)
@@ -226,7 +254,7 @@ class ContrastiveTrainingModule(L.LightningModule):
                 metrics.update(selection.metrics)
         output = replace(output, metrics=metrics)
         if self.memory_bank is not None:
-            self.memory_bank.enqueue(positives, batch)
+            self.memory_bank.enqueue(positives, batch, document_texts=positive_texts)
         return output
 
     @staticmethod
@@ -308,6 +336,8 @@ class ContrastiveTrainingModule(L.LightningModule):
     def on_train_end(self) -> None:
         if self.metrics_logger is not None:
             self.metrics_logger.close_log()
+        if self.memory_bank is not None:
+            self.memory_bank.close()
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         seen: set[int] = set()

--- a/justatom/training/reranker.py
+++ b/justatom/training/reranker.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, Sequence
+
+import torch
+
+from justatom.training.config import RerankerConfig
+
+
+@dataclass(frozen=True)
+class RerankerScores:
+    """Scores and cache telemetry for one collection of query-document pairs."""
+
+    values: tuple[float | None, ...]
+    cache_hits: int
+    cache_misses: int
+    skipped: int
+
+
+class PairScoringBackend(Protocol):
+    @property
+    def fingerprint(self) -> str: ...
+
+    def score_pairs(self, queries: Sequence[str], documents: Sequence[str]) -> list[float]: ...
+
+    def close(self) -> None: ...
+
+
+class RerankerScoreCache:
+    """Small SQLite cache keyed by the complete scoring contract and pair text."""
+
+    def __init__(self, path: str | Path, *, read_only: bool = False):
+        self.path = Path(path).expanduser()
+        if read_only:
+            if not self.path.is_file():
+                raise FileNotFoundError(f"reranker read-only cache does not exist: {self.path}")
+            self.connection = sqlite3.connect(f"file:{self.path}?mode=ro", uri=True)
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.connection = sqlite3.connect(self.path)
+            self.connection.execute("CREATE TABLE IF NOT EXISTS scores (cache_key TEXT PRIMARY KEY, score REAL NOT NULL)")
+            self.connection.commit()
+        self.read_only = read_only
+
+    def get_many(self, keys: Sequence[str]) -> dict[str, float]:
+        if not keys:
+            return {}
+        unique = list(dict.fromkeys(keys))
+        result: dict[str, float] = {}
+        for start in range(0, len(unique), 900):
+            chunk = unique[start : start + 900]
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.connection.execute(
+                f"SELECT cache_key, score FROM scores WHERE cache_key IN ({placeholders})",  # noqa: S608
+                chunk,
+            )
+            result.update((str(key), float(score)) for key, score in rows)
+        return result
+
+    def put_many(self, values: dict[str, float]) -> None:
+        if self.read_only:
+            raise RuntimeError("cannot write to a read-only reranker cache")
+        if not values:
+            return
+        self.connection.executemany(
+            "INSERT OR REPLACE INTO scores(cache_key, score) VALUES (?, ?)",
+            values.items(),
+        )
+        self.connection.commit()
+
+    def close(self) -> None:
+        self.connection.close()
+
+
+class TransformersPairScorer:
+    """Lazy local scorer for Qwen3-style generative yes/no rerankers."""
+
+    _SCORING_CONTRACT = "qwen3-generative-yes-no-v1"
+    _PREFIX = (
+        "<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct "
+        'provided. Note that the answer can only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
+    )
+    _SUFFIX = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+    def __init__(self, config: RerankerConfig):
+        self.config = config
+        self._model: Any | None = None
+        self._tokenizer: Any | None = None
+        self._device: torch.device | None = None
+        self._prefix_tokens: list[int] | None = None
+        self._suffix_tokens: list[int] | None = None
+        self._true_token_id: int | None = None
+        self._false_token_id: int | None = None
+
+    @property
+    def fingerprint(self) -> str:
+        return json.dumps(
+            {
+                "backend": self.config.backend,
+                "contract": self._SCORING_CONTRACT,
+                "model": self.config.model_name_or_path,
+                "revision": self.config.revision,
+                "instruction": self.config.instruction,
+                "max_length": self.config.max_length,
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+    def _resolve_device(self) -> torch.device:
+        if self.config.device != "auto":
+            return torch.device(self.config.device)
+        if torch.cuda.is_available():
+            return torch.device("cuda:0")
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    def _resolve_dtype(self, device: torch.device) -> torch.dtype:
+        values = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }
+        if self.config.dtype != "auto":
+            return values[self.config.dtype]
+        if device.type == "cuda":
+            return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+        if device.type == "mps":
+            return torch.float16
+        return torch.float32
+
+    def _load(self) -> None:
+        if self._model is not None:
+            return
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        device = self._resolve_device()
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.config.model_name_or_path,
+            revision=self.config.revision,
+            local_files_only=self.config.local_files_only,
+            padding_side="left",
+        )
+        tokenizer.pad_token = tokenizer.eos_token
+        model: Any = AutoModelForCausalLM.from_pretrained(
+            self.config.model_name_or_path,
+            revision=self.config.revision,
+            local_files_only=self.config.local_files_only,
+            dtype=self._resolve_dtype(device),
+            low_cpu_mem_usage=True,
+        )
+        model.to(device)
+        model.eval()
+
+        prefix_tokens = tokenizer.encode(self._PREFIX, add_special_tokens=False)
+        suffix_tokens = tokenizer.encode(self._SUFFIX, add_special_tokens=False)
+        if len(prefix_tokens) + len(suffix_tokens) >= self.config.max_length:
+            raise ValueError("reranker.max_length is too small for the Qwen3 scoring template")
+        true_tokens = tokenizer("yes", add_special_tokens=False).input_ids
+        false_tokens = tokenizer("no", add_special_tokens=False).input_ids
+        if len(true_tokens) != 1 or len(false_tokens) != 1:
+            raise RuntimeError("reranker yes/no labels must each map to exactly one token")
+
+        self._model = model
+        self._tokenizer = tokenizer
+        self._device = device
+        self._prefix_tokens = list(prefix_tokens)
+        self._suffix_tokens = list(suffix_tokens)
+        self._true_token_id = int(true_tokens[0])
+        self._false_token_id = int(false_tokens[0])
+
+    def _format_pair(self, query: str, document: str) -> str:
+        return f"<Instruct>: {self.config.instruction}\n<Query>: {query}\n<Document>: {document}"
+
+    @torch.inference_mode()
+    def score_pairs(self, queries: Sequence[str], documents: Sequence[str]) -> list[float]:
+        if len(queries) != len(documents):
+            raise ValueError("queries and documents must have the same length")
+        if not queries:
+            return []
+        self._load()
+        assert self._model is not None
+        assert self._tokenizer is not None
+        assert self._device is not None
+        assert self._prefix_tokens is not None
+        assert self._suffix_tokens is not None
+        assert self._true_token_id is not None
+        assert self._false_token_id is not None
+
+        scores: list[float] = []
+        payload = [self._format_pair(str(query), str(document)) for query, document in zip(queries, documents)]
+        body_length = self.config.max_length - len(self._prefix_tokens) - len(self._suffix_tokens)
+        for start in range(0, len(payload), self.config.batch_size):
+            encoded = self._tokenizer(
+                payload[start : start + self.config.batch_size],
+                padding=False,
+                truncation=True,
+                max_length=body_length,
+                return_attention_mask=False,
+            )
+            encoded["input_ids"] = [
+                self._prefix_tokens + list(token_ids) + self._suffix_tokens for token_ids in encoded["input_ids"]
+            ]
+            inputs = self._tokenizer.pad(encoded, padding=True, return_tensors="pt")
+            inputs = {key: value.to(self._device) for key, value in inputs.items()}
+            logits = self._model(**inputs, use_cache=False, logits_to_keep=1).logits[:, -1, :]
+            binary_logits = torch.stack(
+                (logits[:, self._false_token_id], logits[:, self._true_token_id]),
+                dim=1,
+            )
+            batch_scores = torch.softmax(binary_logits.float(), dim=1)[:, 1].detach().cpu().tolist()
+            if not all(math.isfinite(value) for value in batch_scores):
+                raise RuntimeError("reranker returned a non-finite score")
+            scores.extend(float(value) for value in batch_scores)
+        return scores
+
+    def close(self) -> None:
+        device = self._device
+        self._model = None
+        self._tokenizer = None
+        if device is not None and device.type == "cuda":
+            torch.cuda.empty_cache()
+
+
+class CachedTextReranker:
+    """Pair scorer with deterministic content-addressed persistent caching."""
+
+    def __init__(self, config: RerankerConfig, backend: PairScoringBackend | None = None):
+        self.config = config
+        self.backend = TransformersPairScorer(config) if backend is None else backend
+        cache_config = config.cache
+        self.cache = (
+            None
+            if cache_config.mode == "off"
+            else RerankerScoreCache(cache_config.path, read_only=cache_config.mode == "read-only")
+        )
+
+    def _cache_key(self, query: str, document: str) -> str:
+        payload = json.dumps(
+            [self.backend.fingerprint, query, document],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def score_pairs(self, queries: Sequence[str], documents: Sequence[str]) -> RerankerScores:
+        if len(queries) != len(documents):
+            raise ValueError("queries and documents must have the same length")
+        pairs = [(str(query), str(document)) for query, document in zip(queries, documents)]
+        keys = [self._cache_key(query, document) for query, document in pairs]
+        cached = {} if self.cache is None else self.cache.get_many(keys)
+        values: list[float | None] = [cached.get(key) for key in keys]
+        missing_indices = [index for index, value in enumerate(values) if value is None]
+        hits = len(values) - len(missing_indices)
+
+        if missing_indices and self.config.cache.on_miss == "error":
+            raise RuntimeError(f"reranker cache miss for {len(missing_indices)} pair(s)")
+        if missing_indices and self.config.cache.on_miss == "score":
+            unique_missing: dict[str, tuple[str, str]] = {}
+            for index in missing_indices:
+                unique_missing.setdefault(keys[index], pairs[index])
+            missing_keys = list(unique_missing)
+            missing_pairs = [unique_missing[key] for key in missing_keys]
+            scored = self.backend.score_pairs(
+                [query for query, _ in missing_pairs],
+                [document for _, document in missing_pairs],
+            )
+            if len(scored) != len(missing_keys):
+                raise RuntimeError("reranker backend returned an unexpected number of scores")
+            resolved = dict(zip(missing_keys, scored))
+            if self.cache is not None:
+                self.cache.put_many(resolved)
+            values = [resolved.get(key, value) for key, value in zip(keys, values)]
+
+        skipped = sum(value is None for value in values)
+        return RerankerScores(
+            values=tuple(values),
+            cache_hits=hits,
+            cache_misses=len(missing_indices),
+            skipped=skipped,
+        )
+
+    def close(self) -> None:
+        if self.cache is not None:
+            self.cache.close()
+        self.backend.close()
+
+
+def build_reranker(config: RerankerConfig) -> CachedTextReranker | None:
+    return CachedTextReranker(config) if config.enabled else None
+
+
+__all__ = [
+    "CachedTextReranker",
+    "PairScoringBackend",
+    "RerankerScoreCache",
+    "RerankerScores",
+    "TransformersPairScorer",
+    "build_reranker",
+]

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from justatom.training.config import MemoryBankConfig, RerankerCacheConfig, RerankerConfig
+from justatom.training.memory_bank import ContrastiveMemoryBank
+from justatom.training.reranker import CachedTextReranker
+
+
+class FakePairScorer:
+    fingerprint = "fake-v1"
+
+    def __init__(self, scores: dict[str, float] | None = None):
+        self.scores = scores or {}
+        self.calls: list[list[tuple[str, str]]] = []
+        self.closed = False
+
+    def score_pairs(self, queries, documents):
+        pairs = list(zip(queries, documents))
+        self.calls.append(pairs)
+        return [self.scores.get(document, 0.25) for _, document in pairs]
+
+    def close(self):
+        self.closed = True
+
+
+def reranker_config(**updates):
+    config = RerankerConfig(
+        enabled=True,
+        prefilter_hard_negatives=3,
+        prefilter_random_negatives=0,
+        negatives=1,
+        min_score_gap=0.1,
+        cache=RerankerCacheConfig(mode="off"),
+    )
+    if "cache" not in updates:
+        return replace(config, **updates)
+    return replace(config, **updates)
+
+
+def test_cached_reranker_persists_scores_across_instances(tmp_path):
+    path = tmp_path / "scores.sqlite"
+    config = reranker_config(cache=RerankerCacheConfig(mode="read-write", path=str(path), on_miss="score"))
+    first_backend = FakePairScorer({"doc": 0.75})
+    first = CachedTextReranker(config, backend=first_backend)
+
+    scored = first.score_pairs(["query"], ["doc"])
+    first.close()
+
+    assert scored.values == (0.75,)
+    assert scored.cache_hits == 0 and scored.cache_misses == 1
+    assert first_backend.calls == [[("query", "doc")]]
+
+    second_backend = FakePairScorer({"doc": 0.1})
+    second = CachedTextReranker(config, backend=second_backend)
+    cached = second.score_pairs(["query"], ["doc"])
+    second.close()
+
+    assert cached.values == (0.75,)
+    assert cached.cache_hits == 1 and cached.cache_misses == 0
+    assert second_backend.calls == []
+
+
+def test_read_only_cache_fails_on_unknown_pair(tmp_path):
+    path = tmp_path / "scores.sqlite"
+    writable = reranker_config(cache=RerankerCacheConfig(mode="read-write", path=str(path), on_miss="score"))
+    scorer = CachedTextReranker(writable, backend=FakePairScorer())
+    scorer.score_pairs(["known"], ["doc"])
+    scorer.close()
+    read_only = replace(
+        writable,
+        cache=RerankerCacheConfig(mode="read-only", path=str(path), on_miss="error"),
+    )
+    scorer = CachedTextReranker(read_only, backend=FakePairScorer())
+
+    with pytest.raises(RuntimeError, match="cache miss"):
+        scorer.score_pairs(["unknown"], ["doc"])
+    scorer.close()
+
+
+def test_teacher_filters_ambiguous_candidates_then_keeps_hardest_safe_negative():
+    config = reranker_config()
+    backend = FakePairScorer(
+        {
+            "positive": 0.9,
+            "ambiguous": 0.95,
+            "hard-safe": 0.7,
+            "easy-safe": 0.1,
+        }
+    )
+    reranker = CachedTextReranker(config, backend=backend)
+    bank = ContrastiveMemoryBank(
+        MemoryBankConfig(enabled=True, size=3, mining="random", random_negatives=1),
+        reranker=reranker,
+    )
+    bank.enqueue(
+        F.normalize(torch.tensor([[1.0, 0.0], [0.8, 0.2], [0.0, 1.0]]), dim=-1),
+        {"doc_key_id": torch.tensor([1, 2, 3])},
+        document_texts=["ambiguous", "hard-safe", "easy-safe"],
+    )
+
+    selection = bank.select(
+        batch={"doc_key_id": torch.tensor([99])},
+        query_vectors=F.normalize(torch.tensor([[1.0, 0.0]]), dim=-1),
+        positive_vectors=F.normalize(torch.tensor([[1.0, 0.0]]), dim=-1),
+        step=0,
+        query_texts=["query"],
+        positive_texts=["positive"],
+    )
+
+    assert selection.active_mask is not None
+    assert selection.active_mask.tolist() == [[False, True, False]]
+    assert selection.metrics["reranker/safe_negatives_mean"] == 2.0
+    assert selection.metrics["reranker/ambiguous_mean"] == 1.0
+    assert selection.metrics["reranker/above_positive_mean"] == 1.0
+    assert selection.metrics["memory/active_negatives_mean"] == 1.0
+
+
+def test_disabled_reranker_keeps_original_bank_selection_without_text_metadata():
+    bank = ContrastiveMemoryBank(MemoryBankConfig(enabled=True, size=2, mining="all"))
+    bank.enqueue(F.normalize(torch.eye(2), dim=-1), {"doc_key_id": torch.tensor([1, 2])})
+
+    selection = bank.select(
+        batch={"doc_key_id": torch.tensor([99])},
+        query_vectors=F.normalize(torch.tensor([[1.0, 0.0]]), dim=-1),
+        positive_vectors=F.normalize(torch.tensor([[1.0, 0.0]]), dim=-1),
+        step=0,
+    )
+
+    assert bank.documents is None
+    assert selection.active_mask is not None
+    assert selection.active_mask.tolist() == [[True, True]]
+    assert not any(key.startswith("reranker/") for key in selection.metrics)

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -76,7 +76,45 @@ def test_train_config_serialization_is_plain_and_round_trippable():
     assert payload["experiment"]["role"] == "canonical"
     assert payload["memory_bank"]["margin"]["mode"] == "off"
     assert payload["gradient_projection"]["enabled"] is True
+    assert payload["reranker"]["enabled"] is False
     assert restored == config
+
+
+def test_optional_transformers_reranker_is_typed_and_round_trippable(tmp_path):
+    config = parse_train_config(
+        {
+            "method": "atomic",
+            "reranker": {
+                "enabled": True,
+                "backend": "transformers",
+                "local_files_only": True,
+                "prefilter_hard_negatives": 16,
+                "prefilter_random_negatives": 4,
+                "negatives": 8,
+                "cache": {"mode": "read-write", "path": str(tmp_path / "teacher.sqlite")},
+            },
+        }
+    )
+
+    assert config.reranker.enabled
+    assert config.reranker.backend == "transformers"
+    assert config.reranker.negatives == 8
+    assert parse_train_config(train_config_to_dict(config)) == config
+
+
+def test_reranker_requires_a_memory_bank():
+    with pytest.raises(ValueError, match="requires memory_bank.enabled"):
+        parse_train_config({"method": "vanilla", "reranker": {"enabled": True}})
+
+
+def test_read_only_reranker_cache_cannot_score_misses():
+    with pytest.raises(ValueError, match="does not permit"):
+        parse_train_config(
+            {
+                "method": "atomic",
+                "reranker": {"enabled": True, "cache": {"mode": "read-only", "on_miss": "score"}},
+            }
+        )
 
 
 def test_dataset_loader_options_are_typed_and_round_trippable():

--- a/tests/test_training_module.py
+++ b/tests/test_training_module.py
@@ -9,10 +9,11 @@ from torch import nn
 from torch.utils.data import DataLoader
 
 from justatom.training.alpha_gate import QueryAlphaGate
-from justatom.training.config import ExperimentConfig, ExperimentRole, MarginMode, TrainingMethod
+from justatom.training.config import ExperimentConfig, ExperimentRole, MarginMode, RerankerCacheConfig, TrainingMethod
 from justatom.training.methods import canonical_method_config
 from justatom.training.module import ContrastiveTrainingModule
 from justatom.training.objective import ObjectiveOutput
+from justatom.training.reranker import CachedTextReranker
 
 
 class TinyEncoder(nn.Module):
@@ -84,6 +85,7 @@ def test_module_constructs_only_components_required_by_method():
     assert vanilla.alpha_gate is None and vanilla.memory_bank is None and vanilla.margin_head is None
     assert isinstance(gate.alpha_gate, QueryAlphaGate) and gate.memory_bank is None
     assert atomic.alpha_gate is None and atomic.memory_bank is not None and atomic.margin_head is None
+    assert not atomic.memory_bank.reranker_enabled
     assert atomic.config.gradient_projection.enabled
     assert atomic.automatic_optimization is False
 
@@ -135,6 +137,78 @@ def test_atomic_enqueues_documents_after_objective(monkeypatch):
     module.compute_training_step(tiny_batch(), step=0)
 
     assert events == ["loss", "enqueue"]
+
+
+def test_optional_reranker_is_wired_into_atomic_without_changing_projection():
+    class ConstantBackend:
+        fingerprint = "constant"
+
+        def score_pairs(self, queries, documents):
+            return [0.9 if document.startswith("current") else 0.1 for document in documents]
+
+        def close(self):
+            return None
+
+    base = canonical_method_config(TrainingMethod.ATOMIC)
+    config = replace(
+        base,
+        memory_bank=replace(base.memory_bank, warmup_steps=0),
+        reranker=replace(
+            base.reranker,
+            enabled=True,
+            prefilter_hard_negatives=2,
+            prefilter_random_negatives=0,
+            negatives=1,
+            cache=RerankerCacheConfig(mode="off"),
+        ),
+    )
+    module = ContrastiveTrainingModule.build(TinyEncoder(), config)
+    assert module.memory_bank is not None and module.memory_bank.reranker is not None
+    module.memory_bank.reranker = CachedTextReranker(config.reranker, backend=ConstantBackend())
+    first = {
+        **tiny_batch(),
+        "query_text": ["q1", "q2"],
+        "content_text": ["bank one", "bank two"],
+    }
+    second = {
+        **tiny_batch(),
+        "doc_key_id": torch.tensor([101, 102]),
+        "content_key_id": torch.tensor([111, 112]),
+        "query_key_id": torch.tensor([121, 122]),
+        "query_text": ["q3", "q4"],
+        "content_text": ["current three", "current four"],
+    }
+
+    module.compute_training_step(first, step=0)
+    output = module.compute_training_step(second, step=1)
+
+    assert module.config.gradient_projection.enabled
+    assert module.memory_bank.documents == ["bank one", "bank two", "current three", "current four"]
+    assert output.memory_loss is not None
+    assert output.metrics["reranker/safe_negatives_mean"] == 2.0
+
+
+def test_optional_reranker_does_not_require_gradient_projection():
+    base = canonical_method_config(TrainingMethod.VANILLA)
+    config = replace(
+        base,
+        experiment=ExperimentConfig(role=ExperimentRole.ABLATION),
+        memory_bank=replace(base.memory_bank, enabled=True, size=8),
+        reranker=replace(
+            base.reranker,
+            enabled=True,
+            prefilter_hard_negatives=2,
+            prefilter_random_negatives=0,
+            negatives=1,
+            cache=RerankerCacheConfig(mode="off"),
+        ),
+    )
+
+    module = ContrastiveTrainingModule.build(TinyEncoder(), config)
+
+    assert module.memory_bank is not None and module.memory_bank.reranker_enabled
+    assert not module.config.gradient_projection.enabled
+    assert module.automatic_optimization
 
 
 def test_alpha_mix_weight_uses_exact_linear_warmup():


### PR DESCRIPTION
## Summary

- add an optional local Transformers reranker for online memory-bank false-negative filtering
- keep vanilla bank selection and projected ATOMIC unchanged when the reranker is disabled
- persist content-addressed teacher scores in SQLite for reuse across epochs and seeds
- expose candidate, safety, score-gap, and cache telemetry
- document the runnable Qwen3-Reranker-4B configuration

## Selection flow

1. The student preselects hard and random candidates from the FIFO bank.
2. The frozen teacher scores the labelled positive and each candidate.
3. Candidates within the configured score gap of the positive are rejected as ambiguous.
4. The memory objective receives the hardest remaining safe negatives.
5. If gradient projection is enabled, the existing one-sided projected optimization step runs unchanged.

The reranker only requires an enabled memory bank. A unit contract covers both projected ATOMIC and vanilla+bank without projection. With `reranker.enabled: false`, no teacher, cache, or bank text metadata is created.

## Verification

- 557 passed, 20 deselected: `pytest tests -m "not integration and not network"`
- Black and isort checks pass
- pylint and mypy checks pass
- `mkdocs build --strict` passes
- offline CUDA scoring smoke with Qwen3-Reranker-4B: relevant 0.92414, irrelevant 0.000035
- combined WSL2 CUDA smoke: Qwen3-0.6B LoRA + FIFO bank + Qwen3-Reranker-4B + projected ATOMIC completed 4/4 training steps on the 24 GB RTX 5090 Laptop without OOM or non-finite values
