### PR TITLE
fix(training): prevent alpha-gate collapse

### DIFF
--- a/docs/superpowers/plans/2026-08-13-alpha-gate-objective.md
+++ b/docs/superpowers/plans/2026-08-13-alpha-gate-objective.md
@@ -29,7 +29,7 @@
 - Consumes: `canonical_method_config(method) -> TrainConfig` and `resolve_method(config) -> TrainConfig`.
 - Produces: a canonical method invariant where `config.objective.decoupled is False`; DCL is accepted only for `ExperimentRole.ABLATION`.
 
-- [ ] **Step 1: Write failing method-contract tests**
+- [x] **Step 1: Write failing method-contract tests**
 
 Extend the existing structural profile test with:
 
@@ -56,7 +56,7 @@ def test_canonical_methods_reject_dcl_but_ablation_allows_it(method):
 
 The production mutation caught here is either restoring DCL as a canonical default or allowing a canonical override to silently confound benchmark methods.
 
-- [ ] **Step 2: Run the focused tests and verify RED**
+- [x] **Step 2: Run the focused tests and verify RED**
 
 Run:
 
@@ -66,7 +66,7 @@ conda run -n justatom pytest -q tests/test_training_methods.py
 
 Expected: failure because canonical `vanilla` and `atom_gate` still resolve to DCL, and their canonical DCL configurations are not rejected.
 
-- [ ] **Step 3: Implement the shared method invariant**
+- [x] **Step 3: Implement the shared method invariant**
 
 In `canonical_method_config`, construct a coupled base objective and reuse it:
 
@@ -90,7 +90,7 @@ if role is ExperimentRole.CANONICAL and config.objective.decoupled:
 
 Remove the now-duplicated ATOMIC-only DCL rejection.
 
-- [ ] **Step 4: Run focused configuration tests and verify GREEN**
+- [x] **Step 4: Run focused configuration tests and verify GREEN**
 
 Run:
 
@@ -103,7 +103,7 @@ conda run -n justatom pytest -q \
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit the method contract**
+- [x] **Step 5: Commit the method contract**
 
 ```bash
 git add tests/test_training_methods.py justatom/training/methods.py
@@ -124,7 +124,7 @@ git commit -m "fix(training): align canonical methods on InfoNCE"
 - Consumes: `ObjectiveInputs.alpha: Tensor[B]`, `ObjectiveInputs.query_alt`, and existing semantic/lexical pair score tensors.
 - Produces: SimCSE coefficient `1 - alpha.detach()` and telemetry keys `alpha_aux_weight/{mean,std,min,p05,p50,p95,max}`.
 
-- [ ] **Step 1: Write the failing auxiliary-gradient test**
+- [x] **Step 1: Write the failing auxiliary-gradient test**
 
 Replace the old alpha-gradient assertion in the augment-formula test with a focused contract:
 
@@ -151,7 +151,7 @@ Use two otherwise identical calls with alpha values `0.2` and `0.8` to assert th
 
 The mutation caught is removing `.detach()`, which would restore the shortcut gradient into the alpha head.
 
-- [ ] **Step 2: Write the failing pair-supervision gradient test**
+- [x] **Step 2: Write the failing pair-supervision gradient test**
 
 Use literal semantic and lexical score pairs with opposite preferences:
 
@@ -163,7 +163,7 @@ alpha = torch.tensor([0.4, 0.6], requires_grad=True)
 
 Pass both score matrices and `alpha_mix_weight=0.3`, backpropagate the full loss, and assert a finite, non-zero `alpha.grad`. This catches accidentally detaching alpha globally rather than only at the SimCSE coefficient.
 
-- [ ] **Step 3: Write the failing effective-weight telemetry test**
+- [x] **Step 3: Write the failing effective-weight telemetry test**
 
 Build a real `ATOM_GATE` module, execute `compute_training_step`, and assert:
 
@@ -181,7 +181,7 @@ assert output.metrics["alpha_aux_weight/max"] == pytest.approx(
 
 The mutation caught is losing observability of the effective query-conditioned regularization strength.
 
-- [ ] **Step 4: Run the focused tests and verify RED**
+- [x] **Step 4: Run the focused tests and verify RED**
 
 Run:
 
@@ -193,7 +193,7 @@ conda run -n justatom pytest -q \
 
 Expected: the auxiliary-gradient assertion fails because alpha currently receives a gradient, and the telemetry keys are absent.
 
-- [ ] **Step 5: Implement the local stop-gradient and telemetry**
+- [x] **Step 5: Implement the local stop-gradient and telemetry**
 
 In `ContrastiveObjective.forward`:
 
@@ -211,7 +211,7 @@ metrics.update(scalar_distribution("alpha", alpha))
 metrics.update(scalar_distribution("alpha_aux_weight", 1.0 - alpha.detach()))
 ```
 
-- [ ] **Step 6: Run focused objective and module tests and verify GREEN**
+- [x] **Step 6: Run focused objective and module tests and verify GREEN**
 
 Run:
 
@@ -225,7 +225,7 @@ conda run -n justatom pytest -q \
 
 Expected: all tests pass. If a golden expectation encodes the old live-gate gradient, update it only after confirming its forward values remain unchanged.
 
-- [ ] **Step 7: Commit detached control**
+- [x] **Step 7: Commit detached control**
 
 ```bash
 git add \
@@ -249,7 +249,7 @@ git commit -m "fix(training): detach alpha auxiliary control"
 - Consumes: resolved `TrainConfig.method` and `TrainConfig.objective.decoupled`.
 - Produces: top-level `RunManifest.objective_contract` with `contrastive_kernel` and `alpha_aux_gradient`; documents the exact canonical equations.
 
-- [ ] **Step 1: Write the failing run-manifest contract test**
+- [x] **Step 1: Write the failing run-manifest contract test**
 
 Extend the real YAML round-trip test with:
 
@@ -273,7 +273,7 @@ assert gate.objective_contract["alpha_aux_gradient"] == "detached"
 
 The production mutation caught is omitting the static detach policy from artifacts, which would make old and new runs indistinguishable without commit archaeology.
 
-- [ ] **Step 2: Run the manifest test and verify RED**
+- [x] **Step 2: Run the manifest test and verify RED**
 
 Run:
 
@@ -283,7 +283,7 @@ conda run -n justatom pytest -q tests/test_training_job.py::test_manifest_contai
 
 Expected: failure because `objective_contract` does not exist.
 
-- [ ] **Step 3: Implement objective-contract metadata**
+- [x] **Step 3: Implement objective-contract metadata**
 
 Add a pure helper in `job.py`:
 
@@ -301,7 +301,7 @@ def objective_contract(config: TrainConfig) -> dict[str, str]:
 
 Store its result in `RunManifest.from_config` and emit it from `to_dict`. Keep schema version `1` because this is an additive field and no strict manifest reader exists.
 
-- [ ] **Step 4: Update the public training documentation**
+- [x] **Step 4: Update the public training documentation**
 
 In `docs/training.md`:
 
@@ -311,7 +311,7 @@ In `docs/training.md`:
 - state that DCL is an ablation-only override;
 - remove wording that claims only ATOMIC uses coupled InfoNCE.
 
-- [ ] **Step 5: Run focused tests and documentation build**
+- [x] **Step 5: Run focused tests and documentation build**
 
 Run:
 
@@ -322,7 +322,7 @@ conda run -n justatom mkdocs build --strict
 
 Expected: tests and strict documentation build pass.
 
-- [ ] **Step 6: Commit metadata and documentation**
+- [x] **Step 6: Commit metadata and documentation**
 
 ```bash
 git add tests/test_training_job.py justatom/training/job.py docs/training.md
@@ -340,7 +340,7 @@ git commit -m "docs(training): record alpha objective contract"
 - Consumes: all prior task commits.
 - Produces: a verified branch and a draft pull request against `master`.
 
-- [ ] **Step 1: Run formatting and static checks configured by the repository**
+- [x] **Step 1: Run formatting and static checks configured by the repository**
 
 Inspect `pyproject.toml`/CI and run the exact local equivalents. At minimum:
 
@@ -349,7 +349,7 @@ conda run -n justatom black --check justatom tests
 conda run -n justatom isort --check-only justatom tests
 ```
 
-- [ ] **Step 2: Run the complete offline test suite**
+- [x] **Step 2: Run the complete offline test suite**
 
 ```bash
 conda run -n justatom pytest -q tests -m "not integration and not network"
@@ -357,7 +357,7 @@ conda run -n justatom pytest -q tests -m "not integration and not network"
 
 Expected: all selected tests pass with no new warnings attributable to this change.
 
-- [ ] **Step 3: Inspect the final diff and branch hygiene**
+- [x] **Step 3: Inspect the final diff and branch hygiene**
 
 ```bash
 git diff --check origin/master...HEAD

--- a/docs/superpowers/plans/2026-08-13-alpha-gate-objective.md
+++ b/docs/superpowers/plans/2026-08-13-alpha-gate-objective.md
@@ -367,7 +367,7 @@ git status --short
 
 Confirm only the spec, plan, production files, focused tests, and public training documentation are tracked in the branch. Do not add unrelated untracked files.
 
-- [ ] **Step 4: Push and open the draft PR**
+- [x] **Step 4: Push and open the draft PR**
 
 ```bash
 git push -u origin fix/alpha-gate-objective

--- a/docs/superpowers/plans/2026-08-13-alpha-gate-objective.md
+++ b/docs/superpowers/plans/2026-08-13-alpha-gate-objective.md
@@ -1,0 +1,379 @@
+# Alpha-Gate Objective Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all canonical methods use coupled InfoNCE and prevent the SimCSE auxiliary path from training `alpha(q)` toward the loss-disabling solution.
+
+**Architecture:** Method resolution owns the shared coupled-InfoNCE contract. `ContrastiveObjective` uses live alpha for semantic/lexical pair supervision and `alpha.detach()` only for SimCSE weighting; `ContrastiveTrainingModule` publishes the resulting effective weight distribution. `RunManifest` records this static objective contract alongside the resolved configuration.
+
+**Tech Stack:** Python 3.10-3.13, PyTorch, PyTorch Lightning, pytest, dataclasses, YAML.
+
+## Global Constraints
+
+- Public method names remain exactly `vanilla`, `atom_gate`, and `atomic`.
+- All canonical methods resolve to `objective.decoupled: false`.
+- DCL remains available only when `experiment.role: ablation` is explicit.
+- Detach only the alpha value used to weight SimCSE; keep alpha live in pair mixing and entropy regularization.
+- Introduce no new public hyperparameters, heads, budget losses, or changes to ATOMIC memory projection.
+- Existing untracked research files and scripts are outside this change and must remain untouched.
+
+---
+
+### Task 1: Canonical Coupled-InfoNCE Contract
+
+**Files:**
+- Modify: `tests/test_training_methods.py`
+- Modify: `justatom/training/methods.py`
+
+**Interfaces:**
+- Consumes: `canonical_method_config(method) -> TrainConfig` and `resolve_method(config) -> TrainConfig`.
+- Produces: a canonical method invariant where `config.objective.decoupled is False`; DCL is accepted only for `ExperimentRole.ABLATION`.
+
+- [ ] **Step 1: Write failing method-contract tests**
+
+Extend the existing structural profile test with:
+
+```python
+assert not vanilla.objective.decoupled
+assert not gate.objective.decoupled
+assert not atomic.objective.decoupled
+```
+
+Add a parameterized behavior test:
+
+```python
+@pytest.mark.parametrize("method", list(TrainingMethod))
+def test_canonical_methods_reject_dcl_but_ablation_allows_it(method):
+    config = canonical_method_config(method)
+    dcl = replace(config, objective=replace(config.objective, decoupled=True))
+
+    with pytest.raises(ValueError, match="coupled InfoNCE.*experiment.role=ablation"):
+        resolve_method(dcl)
+
+    ablation = replace(dcl, experiment=ExperimentConfig(role=ExperimentRole.ABLATION, seed=42))
+    assert resolve_method(ablation).objective.decoupled
+```
+
+The production mutation caught here is either restoring DCL as a canonical default or allowing a canonical override to silently confound benchmark methods.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+conda run -n justatom pytest -q tests/test_training_methods.py
+```
+
+Expected: failure because canonical `vanilla` and `atom_gate` still resolve to DCL, and their canonical DCL configurations are not rejected.
+
+- [ ] **Step 3: Implement the shared method invariant**
+
+In `canonical_method_config`, construct a coupled base objective and reuse it:
+
+```python
+objective = ObjectiveConfig(decoupled=False)
+if method is TrainingMethod.VANILLA:
+    return TrainConfig(method=method, objective=objective)
+
+atom_gate_objective = replace(objective, simcse_dropout_weight=0.1)
+```
+
+Before method-specific structural validation in `resolve_method`, enforce:
+
+```python
+if role is ExperimentRole.CANONICAL and config.objective.decoupled:
+    raise ValueError(
+        f"canonical {method.value} requires coupled InfoNCE; "
+        "use experiment.role=ablation for DCL"
+    )
+```
+
+Remove the now-duplicated ATOMIC-only DCL rejection.
+
+- [ ] **Step 4: Run focused configuration tests and verify GREEN**
+
+Run:
+
+```bash
+conda run -n justatom pytest -q \
+  tests/test_training_methods.py \
+  tests/test_training_config.py \
+  tests/test_train_cli.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the method contract**
+
+```bash
+git add tests/test_training_methods.py justatom/training/methods.py
+git commit -m "fix(training): align canonical methods on InfoNCE"
+```
+
+---
+
+### Task 2: Detached Alpha Auxiliary Control
+
+**Files:**
+- Modify: `tests/test_training_objective.py`
+- Modify: `tests/test_training_module.py`
+- Modify: `justatom/training/objective.py`
+- Modify: `justatom/training/module.py`
+
+**Interfaces:**
+- Consumes: `ObjectiveInputs.alpha: Tensor[B]`, `ObjectiveInputs.query_alt`, and existing semantic/lexical pair score tensors.
+- Produces: SimCSE coefficient `1 - alpha.detach()` and telemetry keys `alpha_aux_weight/{mean,std,min,p05,p50,p95,max}`.
+
+- [ ] **Step 1: Write the failing auxiliary-gradient test**
+
+Replace the old alpha-gradient assertion in the augment-formula test with a focused contract:
+
+```python
+auxiliary_only = output.loss - output.main_per_row.mean()
+auxiliary_only.backward()
+
+assert alpha.grad is None
+assert queries.grad is not None and float(queries.grad.abs().sum()) > 0.0
+assert alternate_queries.grad is not None and float(alternate_queries.grad.abs().sum()) > 0.0
+```
+
+Retain the hand-derived forward assertion:
+
+```python
+expected = (
+    output.main_per_row
+    + (1.0 - alpha.detach()) * 0.1 * output.simcse_per_row
+).mean()
+torch.testing.assert_close(output.loss, expected)
+```
+
+Use two otherwise identical calls with alpha values `0.2` and `0.8` to assert that the detached control still changes the forward loss.
+
+The mutation caught is removing `.detach()`, which would restore the shortcut gradient into the alpha head.
+
+- [ ] **Step 2: Write the failing pair-supervision gradient test**
+
+Use literal semantic and lexical score pairs with opposite preferences:
+
+```python
+semantic = torch.tensor([[0.9, 0.1], [0.2, 0.8]])
+lexical = torch.tensor([[0.1, 0.8], [0.9, 0.2]])
+alpha = torch.tensor([0.4, 0.6], requires_grad=True)
+```
+
+Pass both score matrices and `alpha_mix_weight=0.3`, backpropagate the full loss, and assert a finite, non-zero `alpha.grad`. This catches accidentally detaching alpha globally rather than only at the SimCSE coefficient.
+
+- [ ] **Step 3: Write the failing effective-weight telemetry test**
+
+Build a real `ATOM_GATE` module, execute `compute_training_step`, and assert:
+
+```python
+assert output.metrics["alpha_aux_weight/mean"] == pytest.approx(
+    1.0 - output.metrics["alpha/mean"]
+)
+assert output.metrics["alpha_aux_weight/min"] == pytest.approx(
+    1.0 - output.metrics["alpha/max"]
+)
+assert output.metrics["alpha_aux_weight/max"] == pytest.approx(
+    1.0 - output.metrics["alpha/min"]
+)
+```
+
+The mutation caught is losing observability of the effective query-conditioned regularization strength.
+
+- [ ] **Step 4: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+conda run -n justatom pytest -q \
+  tests/test_training_objective.py \
+  tests/test_training_module.py
+```
+
+Expected: the auxiliary-gradient assertion fails because alpha currently receives a gradient, and the telemetry keys are absent.
+
+- [ ] **Step 5: Implement the local stop-gradient and telemetry**
+
+In `ContrastiveObjective.forward`:
+
+```python
+auxiliary_weight = 1.0 - alpha.detach()
+per_row = main + auxiliary_weight * auxiliary
+```
+
+Do not alter the live-alpha expressions used by `mixed_pair` or entropy.
+
+In `ContrastiveTrainingModule.compute_training_step`, next to existing alpha telemetry:
+
+```python
+metrics.update(scalar_distribution("alpha", alpha))
+metrics.update(scalar_distribution("alpha_aux_weight", 1.0 - alpha.detach()))
+```
+
+- [ ] **Step 6: Run focused objective and module tests and verify GREEN**
+
+Run:
+
+```bash
+conda run -n justatom pytest -q \
+  tests/test_training_objective.py \
+  tests/test_training_module.py \
+  tests/test_training_golden.py \
+  tests/test_alpha_gate.py
+```
+
+Expected: all tests pass. If a golden expectation encodes the old live-gate gradient, update it only after confirming its forward values remain unchanged.
+
+- [ ] **Step 7: Commit detached control**
+
+```bash
+git add \
+  tests/test_training_objective.py \
+  tests/test_training_module.py \
+  justatom/training/objective.py \
+  justatom/training/module.py
+git commit -m "fix(training): detach alpha auxiliary control"
+```
+
+---
+
+### Task 3: Reproducibility Metadata and User Documentation
+
+**Files:**
+- Modify: `tests/test_training_job.py`
+- Modify: `justatom/training/job.py`
+- Modify: `docs/training.md`
+
+**Interfaces:**
+- Consumes: resolved `TrainConfig.method` and `TrainConfig.objective.decoupled`.
+- Produces: top-level `RunManifest.objective_contract` with `contrastive_kernel` and `alpha_aux_gradient`; documents the exact canonical equations.
+
+- [ ] **Step 1: Write the failing run-manifest contract test**
+
+Extend the real YAML round-trip test with:
+
+```python
+assert loaded["objective_contract"] == {
+    "contrastive_kernel": "coupled_infonce",
+    "alpha_aux_gradient": "not_applicable",
+}
+```
+
+Add an `ATOM_GATE` manifest assertion:
+
+```python
+gate = RunManifest.from_config(
+    canonical_method_config(TrainingMethod.ATOM_GATE),
+    git_commit="abc123",
+    git_dirty=False,
+)
+assert gate.objective_contract["alpha_aux_gradient"] == "detached"
+```
+
+The production mutation caught is omitting the static detach policy from artifacts, which would make old and new runs indistinguishable without commit archaeology.
+
+- [ ] **Step 2: Run the manifest test and verify RED**
+
+Run:
+
+```bash
+conda run -n justatom pytest -q tests/test_training_job.py::test_manifest_contains_resolved_method_seed_and_git_state
+```
+
+Expected: failure because `objective_contract` does not exist.
+
+- [ ] **Step 3: Implement objective-contract metadata**
+
+Add a pure helper in `job.py`:
+
+```python
+def objective_contract(config: TrainConfig) -> dict[str, str]:
+    return {
+        "contrastive_kernel": (
+            "decoupled_infonce" if config.objective.decoupled else "coupled_infonce"
+        ),
+        "alpha_aux_gradient": (
+            "detached" if config.method is TrainingMethod.ATOM_GATE else "not_applicable"
+        ),
+    }
+```
+
+Store its result in `RunManifest.from_config` and emit it from `to_dict`. Keep schema version `1` because this is an additive field and no strict manifest reader exists.
+
+- [ ] **Step 4: Update the public training documentation**
+
+In `docs/training.md`:
+
+- describe one shared coupled InfoNCE row loss for all canonical methods;
+- write the gate equation as `(1 - stop_gradient(alpha_i)) lambda_sc L_i_sc`;
+- state that alpha remains live for semantic/lexical pair supervision;
+- state that DCL is an ablation-only override;
+- remove wording that claims only ATOMIC uses coupled InfoNCE.
+
+- [ ] **Step 5: Run focused tests and documentation build**
+
+Run:
+
+```bash
+conda run -n justatom pytest -q tests/test_training_job.py tests/test_training_config.py
+conda run -n justatom mkdocs build --strict
+```
+
+Expected: tests and strict documentation build pass.
+
+- [ ] **Step 6: Commit metadata and documentation**
+
+```bash
+git add tests/test_training_job.py justatom/training/job.py docs/training.md
+git commit -m "docs(training): record alpha objective contract"
+```
+
+---
+
+### Task 4: Full Verification and Draft PR
+
+**Files:**
+- Verify only; modify only when a failing repository-owned check exposes a regression caused by Tasks 1-3.
+
+**Interfaces:**
+- Consumes: all prior task commits.
+- Produces: a verified branch and a draft pull request against `master`.
+
+- [ ] **Step 1: Run formatting and static checks configured by the repository**
+
+Inspect `pyproject.toml`/CI and run the exact local equivalents. At minimum:
+
+```bash
+conda run -n justatom black --check justatom tests
+conda run -n justatom isort --check-only justatom tests
+```
+
+- [ ] **Step 2: Run the complete offline test suite**
+
+```bash
+conda run -n justatom pytest -q tests -m "not integration and not network"
+```
+
+Expected: all selected tests pass with no new warnings attributable to this change.
+
+- [ ] **Step 3: Inspect the final diff and branch hygiene**
+
+```bash
+git diff --check origin/master...HEAD
+git diff --stat origin/master...HEAD
+git status --short
+```
+
+Confirm only the spec, plan, production files, focused tests, and public training documentation are tracked in the branch. Do not add unrelated untracked files.
+
+- [ ] **Step 4: Push and open the draft PR**
+
+```bash
+git push -u origin fix/alpha-gate-objective
+gh pr create --draft --base master --head fix/alpha-gate-objective \
+  --title "fix(training): prevent alpha-gate collapse" \
+  --body-file /tmp/justatom-alpha-gate-pr.md
+```
+
+The PR body must summarize the mathematical shortcut, the local stop-gradient, the shared coupled baseline, telemetry/manifest additions, test evidence, and the requirement to rerun matched benchmarks rather than pooling historical metrics.

--- a/docs/superpowers/specs/2026-08-13-alpha-gate-objective-design.md
+++ b/docs/superpowers/specs/2026-08-13-alpha-gate-objective-design.md
@@ -1,0 +1,216 @@
+# Alpha-Gate Objective: Coupled Baseline and Detached Control
+
+**Date:** 2026-08-13
+
+**Branch:** `fix/alpha-gate-objective`
+
+**Status:** approved design
+
+## 1. Problem
+
+The canonical `atom_gate` objective currently uses one query-conditional
+coefficient for two different roles:
+
+1. mixing semantic and lexical pair scores;
+2. attenuating the SimCSE auxiliary loss.
+
+For query `i`, the relevant part of the current objective is
+
+\[
+L_i = L_{\mathrm{main},i}
+    + (1-\alpha_i)L_{\mathrm{aux},i}
+    + \lambda_{\mathrm{mix}}L_{\mathrm{mix},i}(\alpha_i).
+\]
+
+Its direct gradient with respect to the controller is
+
+\[
+\frac{\partial L_i}{\partial \alpha_i}
+= -L_{\mathrm{aux},i}
++ \lambda_{\mathrm{mix}}
+  \frac{\partial L_{\mathrm{mix},i}}{\partial \alpha_i}.
+\]
+
+With standard coupled contrastive cross-entropy,
+`L_aux >= 0`. The auxiliary path therefore rewards increasing `alpha` even
+when that increase has no semantic or lexical justification. At `alpha = 1`,
+the head can disable SimCSE. Changing DCL to coupled InfoNCE does not remove
+this degeneracy; it only makes the sign of the shortcut unambiguous.
+
+There is a second comparison problem: the canonical methods do not currently
+share one contrastive kernel. `vanilla` and `atom_gate` inherit DCL, whereas
+`atomic` explicitly uses coupled InfoNCE. This confounds method comparisons.
+
+## 2. Decision
+
+Use coupled InfoNCE as the canonical contrastive kernel for all three public
+training methods, and treat `alpha(q)` as a detached control value only on the
+SimCSE weighting path.
+
+The new `atom_gate` loss is
+
+\[
+\boxed{
+L_i = L_{\mathrm{InfoNCE},i}
+    + \left(1-\operatorname{sg}[\alpha_i]\right)
+      \lambda_{\mathrm{aux}}L_{\mathrm{SimCSE},i}
+    + \lambda_{\mathrm{mix}}L_{\mathrm{mix},i}(\alpha_i)
+    - \lambda_H H(\alpha_i)
+}
+\]
+
+where `sg` is the stop-gradient operator. The entropy term remains optional
+and keeps its existing configuration and default.
+
+This gives the controller one coherent source of supervision:
+
+\[
+\frac{\partial L_i}{\partial \alpha_i}
+= \lambda_{\mathrm{mix}}
+  \frac{\partial L_{\mathrm{mix},i}}{\partial \alpha_i}
+  - \lambda_H\frac{\partial H(\alpha_i)}{\partial \alpha_i}.
+\]
+
+The encoder still receives the query-dependent auxiliary gradient
+
+\[
+\frac{\partial L_i}{\partial \theta}\bigg|_{\mathrm{aux}}
+= \left(1-\operatorname{sg}[\alpha_i]\right)
+  \lambda_{\mathrm{aux}}
+  \frac{\partial L_{\mathrm{SimCSE},i}}{\partial \theta},
+\]
+
+but neither the alpha head nor the encoder can reduce the current auxiliary
+loss through the derivative of the gate itself.
+
+## 3. Canonical Method Contract
+
+All canonical methods use `objective.decoupled: false`:
+
+| Method | Primary objective | Additional mechanism |
+|---|---|---|
+| `vanilla` | coupled InfoNCE | none |
+| `atom_gate` | coupled InfoNCE | detached alpha-controlled SimCSE plus semantic/lexical pair mixing |
+| `atomic` | coupled InfoNCE | FIFO memory negatives with projected memory gradients |
+
+This is a structural contract, not merely a YAML default. Canonical method
+resolution must produce it even when the caller supplies only the method name.
+Explicit incompatible overrides in a canonical experiment must be rejected.
+Research ablations may enable DCL only under `experiment.role: ablation`.
+
+## 4. Alpha Data Flow
+
+For each training batch:
+
+1. The encoder produces normalized query and positive embeddings.
+2. `QueryAlphaGate` produces one `alpha_i` per query.
+3. Semantic positive/negative scores come from cosine similarity.
+4. Lexical positive/negative scores come from the normalized lexical lookup.
+5. The live `alpha` enters `L_mix`, which trains the controller to choose the
+   useful semantic/lexical contribution for each query.
+6. `alpha.detach()` enters the SimCSE coefficient `1 - alpha.detach()`.
+7. Telemetry records the live alpha distribution and the effective auxiliary
+   weight distribution without changing either graph.
+
+The detach is local to auxiliary weighting. It must not be applied to the
+semantic/lexical mixing objective or to the optional entropy regularizer.
+
+## 5. Configuration
+
+No new public hyperparameters are introduced.
+
+Existing fields retain their meanings:
+
+- `objective.simcse_dropout_weight`: global SimCSE scale
+  `lambda_aux`;
+- `alpha_gate.mix_weight`: weight of semantic/lexical pair supervision;
+- `alpha_gate.mix_weight_warmup_steps`: linear warmup for pair supervision;
+- `alpha_gate.entropy_weight`: optional anti-saturation regularizer.
+
+For the canonical `atom_gate` profile:
+
+```yaml
+objective:
+  decoupled: false
+  simcse_dropout_weight: 0.1
+
+alpha_gate:
+  enabled: true
+  mix_weight: 0.3
+```
+
+The implementation must not add a mean-alpha target, budget penalty, second
+gate head, or another loss coefficient in this change.
+
+## 6. Telemetry
+
+Keep the existing `alpha/*` distribution and loss metrics. Add an effective
+auxiliary-weight distribution under `alpha_aux_weight/*`, computed as
+`1 - alpha.detach()`.
+
+The minimum required observables are:
+
+- alpha mean, minimum, maximum, and standard deviation;
+- effective auxiliary-weight mean, minimum, maximum, and standard deviation;
+- unweighted SimCSE loss;
+- semantic/lexical mixing loss;
+- main coupled InfoNCE loss.
+
+These metrics allow experiments to distinguish a legitimate semantic-heavy
+alpha distribution from optimization collapse.
+
+## 7. Validation
+
+Implementation follows test-first development.
+
+### 7.1 Objective gradient contract
+
+A focused unit test must demonstrate all of the following:
+
+- changing alpha changes the forward value of the weighted auxiliary term;
+- the auxiliary-only path produces no alpha gradient;
+- the auxiliary-only path still produces encoder gradients;
+- adding semantic/lexical pair supervision produces a finite, non-zero alpha
+  gradient.
+
+### 7.2 Method resolution
+
+Tests must assert that canonical `vanilla`, `atom_gate`, and `atomic` all
+resolve to `decoupled == false`. A canonical DCL override must fail with a
+clear message, while the same override remains available for an explicit
+ablation role.
+
+### 7.3 Regression coverage
+
+The existing tests for vanilla training, alpha telemetry, lexical score
+recovery, memory-bank projection, configuration serialization, and CLI
+resolution must remain green. The complete offline test suite is required
+before publication.
+
+## 8. Experimental Consequence
+
+Metrics produced before this change used a different optimization contract
+and must not be silently pooled with new canonical results. New benchmark
+runs must record the resolved `decoupled` value and the alpha detach policy in
+their metadata.
+
+The first matched comparison after implementation is:
+
+1. same model checkpoint;
+2. same dataset split and seed;
+3. same batch size, epoch count, optimizer, temperature, and LoRA settings;
+4. `vanilla` versus `atom_gate` versus `atomic`;
+5. at least two seeds for any result used as dissertation evidence.
+
+The scientific claim is limited to query-conditioned regularization whose
+controller is supervised by retrieval evidence. This design does not claim
+that unconstrained loss attenuation is useful.
+
+## 9. Out of Scope
+
+- a separate `w(q)` auxiliary-weight head;
+- a batch-level alpha budget or target mean;
+- query-conditional temperature;
+- changes to ATOMIC gradient projection or memory selection;
+- inference-time use of the alpha head;
+- reinterpretation of historical benchmark tables.

--- a/docs/training.md
+++ b/docs/training.md
@@ -80,6 +80,13 @@ random candidates per query, and memory weight `1.0`. It does not construct
 the alpha gate or a query-margin head. Structural additions must be labeled as
 ablations:
 
+Run manifests record the resolved kernel and alpha gradient policy under
+`objective_contract`. Results produced before this contract was introduced
+used different canonical objectives and must not be pooled with or directly
+compared against new runs. Re-run matched methods with the same model, split,
+seed, batch size, optimizer, and epoch count before drawing method-level
+conclusions.
+
 ```bash
 python -m justatom.api.train \
   --config configs/train.yaml \

--- a/docs/training.md
+++ b/docs/training.md
@@ -4,9 +4,9 @@ Justatom has one production training path and three public methods.
 
 | Method | Primary objective | Auxiliary objective | Gradient control |
 | --- | --- | --- | --- |
-| `vanilla` | InfoNCE | none | none |
-| `atom_gate` | InfoNCE | query-controlled SimCSE pressure | learned `alpha(q)` |
-| `atomic` | standard coupled InfoNCE | detached online memory | one-sided orthogonal projection |
+| `vanilla` | coupled InfoNCE | none | none |
+| `atom_gate` | coupled InfoNCE | query-controlled SimCSE and semantic/lexical pairs | stop-gradient on the SimCSE coefficient |
+| `atomic` | coupled InfoNCE | detached online memory | one-sided orthogonal projection |
 
 ## Objective
 
@@ -17,22 +17,24 @@ in-batch similarity matrix is
 S = Q P^T,       S_ij = cosine(q_i, p_j).
 ```
 
-The decoupled InfoNCE row loss is
+All three canonical methods use the same coupled InfoNCE row loss:
 
 ```text
-L_i = -S_ii / tau + log sum_{j != i} exp(S_ij / tau).
+L_i = -S_ii / tau + log sum_j exp(S_ij / tau).
 ```
 
 `atom_gate` learns a query-only scalar `alpha_i = alpha(q_i)` and adds the
 SimCSE dropout-view pressure per query:
 
 ```text
-L_i_gate = L_i + (1 - alpha_i) lambda_sc L_i_sc.
+L_i_gate = L_i + (1 - stop_gradient(alpha_i)) lambda_sc L_i_sc.
 ```
 
 When lexical metadata is available, the same gate also controls a pairwise
-semantic/lexical auxiliary term. The gate is training-only; the saved encoder
-has the same inference interface as the source embedding model.
+semantic/lexical auxiliary term. Alpha remains live on that pair-supervision
+path, which trains the gate, but the gate cannot lower the current SimCSE loss
+by moving toward one. The gate is training-only; the saved encoder has the
+same inference interface as the source embedding model.
 
 ## ATOMIC: protected online memory
 
@@ -69,10 +71,14 @@ implemented with ordinary PyTorch operations and works on CUDA, MPS, and CPU.
 ## Canonical Profiles
 
 Selecting a method applies its registered defaults before YAML and CLI
-overrides. Canonical `atomic` uses standard coupled InfoNCE, a 512-entry FIFO
-bank, 50 optimizer-step warmup, 12 random candidates per query, and memory
-weight `1.0`. It does not construct the old alpha gate or a query-margin head.
-Structural additions must be labeled as ablations:
+overrides. Canonical `vanilla`, `atom_gate`, and `atomic` share coupled
+InfoNCE so method comparisons do not change the primary contrastive kernel.
+Using decoupled InfoNCE requires `experiment.role: ablation` explicitly.
+
+Canonical `atomic` adds a 512-entry FIFO bank, 50 optimizer-step warmup, 12
+random candidates per query, and memory weight `1.0`. It does not construct
+the alpha gate or a query-margin head. Structural additions must be labeled as
+ablations:
 
 ```bash
 python -m justatom.api.train \

--- a/justatom/training/job.py
+++ b/justatom/training/job.py
@@ -64,12 +64,8 @@ def _git_output(*args: str) -> str | None:
 
 def objective_contract(config: TrainConfig) -> dict[str, str]:
     return {
-        "contrastive_kernel": (
-            "decoupled_infonce" if config.objective.decoupled else "coupled_infonce"
-        ),
-        "alpha_aux_gradient": (
-            "detached" if config.method is TrainingMethod.ATOM_GATE else "not_applicable"
-        ),
+        "contrastive_kernel": ("decoupled_infonce" if config.objective.decoupled else "coupled_infonce"),
+        "alpha_aux_gradient": ("detached" if config.method is TrainingMethod.ATOM_GATE else "not_applicable"),
     }
 
 

--- a/justatom/training/job.py
+++ b/justatom/training/job.py
@@ -62,6 +62,17 @@ def _git_output(*args: str) -> str | None:
     return value if result.returncode == 0 and value else None
 
 
+def objective_contract(config: TrainConfig) -> dict[str, str]:
+    return {
+        "contrastive_kernel": (
+            "decoupled_infonce" if config.objective.decoupled else "coupled_infonce"
+        ),
+        "alpha_aux_gradient": (
+            "detached" if config.method is TrainingMethod.ATOM_GATE else "not_applicable"
+        ),
+    }
+
+
 @dataclass(frozen=True)
 class RunManifest:
     schema_version: int
@@ -70,6 +81,7 @@ class RunManifest:
     created_at: str
     git_commit: str | None
     git_dirty: bool | None
+    objective_contract: dict[str, str]
     resolved_config: dict[str, Any]
 
     @classmethod
@@ -88,6 +100,7 @@ class RunManifest:
             created_at=datetime.now(timezone.utc).isoformat(),
             git_commit=git_commit,
             git_dirty=git_dirty,
+            objective_contract=objective_contract(config),
             resolved_config=payload,
         )
 
@@ -106,6 +119,7 @@ class RunManifest:
             "created_at": self.created_at,
             "git_commit": self.git_commit,
             "git_dirty": self.git_dirty,
+            "objective_contract": self.objective_contract,
             "resolved_config": self.resolved_config,
         }
 

--- a/justatom/training/methods.py
+++ b/justatom/training/methods.py
@@ -48,9 +48,7 @@ def resolve_method(config: TrainConfig) -> TrainConfig:
     bank = config.memory_bank
 
     if role is ExperimentRole.CANONICAL and config.objective.decoupled:
-        raise ValueError(
-            f"canonical {method.value} requires coupled InfoNCE; use experiment.role=ablation for DCL"
-        )
+        raise ValueError(f"canonical {method.value} requires coupled InfoNCE; use experiment.role=ablation for DCL")
 
     if method is TrainingMethod.VANILLA:
         if gate.enabled:

--- a/justatom/training/methods.py
+++ b/justatom/training/methods.py
@@ -16,13 +16,14 @@ from justatom.training.config import (
 
 def canonical_method_config(method: TrainingMethod | str) -> TrainConfig:
     method = TrainingMethod(method)
+    objective = ObjectiveConfig(decoupled=False)
     if method is TrainingMethod.VANILLA:
-        return TrainConfig(method=method)
+        return TrainConfig(method=method, objective=objective)
 
-    objective = ObjectiveConfig(simcse_dropout_weight=0.1)
+    atom_gate_objective = replace(objective, simcse_dropout_weight=0.1)
     alpha_gate = AlphaGateConfig(enabled=True, mix_weight=0.3)
     if method is TrainingMethod.ATOM_GATE:
-        return TrainConfig(method=method, objective=objective, alpha_gate=alpha_gate)
+        return TrainConfig(method=method, objective=atom_gate_objective, alpha_gate=alpha_gate)
 
     memory_bank = MemoryBankConfig(
         enabled=True,
@@ -34,7 +35,7 @@ def canonical_method_config(method: TrainingMethod | str) -> TrainConfig:
     )
     return TrainConfig(
         method=method,
-        objective=ObjectiveConfig(decoupled=False),
+        objective=objective,
         memory_bank=memory_bank,
         gradient_projection=GradientProjectionConfig(enabled=True),
     )
@@ -45,6 +46,11 @@ def resolve_method(config: TrainConfig) -> TrainConfig:
     role = config.experiment.role
     gate = config.alpha_gate
     bank = config.memory_bank
+
+    if role is ExperimentRole.CANONICAL and config.objective.decoupled:
+        raise ValueError(
+            f"canonical {method.value} requires coupled InfoNCE; use experiment.role=ablation for DCL"
+        )
 
     if method is TrainingMethod.VANILLA:
         if gate.enabled:
@@ -80,8 +86,6 @@ def resolve_method(config: TrainConfig) -> TrainConfig:
         raise ValueError("atomic requires gradient_projection.enabled=true")
 
     if role is ExperimentRole.CANONICAL:
-        if config.objective.decoupled:
-            raise ValueError("canonical atomic requires standard coupled InfoNCE")
         if bank.margin.mode is not MarginMode.OFF:
             raise ValueError("canonical atomic keeps memory margin off; use experiment.role=ablation to enable it")
         if bank.adaptive.enabled:

--- a/justatom/training/module.py
+++ b/justatom/training/module.py
@@ -218,6 +218,7 @@ class ContrastiveTrainingModule(L.LightningModule):
             metrics.update(batch_retrieval_metrics(queries @ positives.T))
             if alpha is not None:
                 metrics.update(scalar_distribution("alpha", alpha))
+                metrics.update(scalar_distribution("alpha_aux_weight", 1.0 - alpha.detach()))
             if raw_margin is not None:
                 metrics.update(scalar_distribution("margin/raw", raw_margin))
             if margin is not None:

--- a/justatom/training/module.py
+++ b/justatom/training/module.py
@@ -421,7 +421,13 @@ class ContrastiveTrainingModule(L.LightningModule):
         payload = torch.load(path, map_location=map_location)
         if payload.get("schema_version") != 1:
             raise ValueError(f"Unsupported research checkpoint schema: {payload.get('schema_version')!r}")
-        config = parse_train_config(payload["resolved_config"])
+        resolved_config = dict(payload["resolved_config"])
+        objective_config = dict(resolved_config.get("objective", {}))
+        experiment_config = dict(resolved_config.get("experiment", {}))
+        if objective_config.get("decoupled") is True and experiment_config.get("role") == "canonical":
+            experiment_config["role"] = "ablation"
+            resolved_config["experiment"] = experiment_config
+        config = parse_train_config(resolved_config)
         module = cls.build(encoder, config, lexical_lookup=lexical_lookup)
         module.load_state_dict(payload["state_dict"], strict=True)
         return module, list(payload.get("optimizer_states", []))

--- a/justatom/training/objective.py
+++ b/justatom/training/objective.py
@@ -108,7 +108,8 @@ class ContrastiveObjective(nn.Module):
             alpha = inputs.alpha.view(-1)
             if alpha.shape != main.shape:
                 raise ValueError(f"alpha must have shape {tuple(main.shape)}, got {tuple(alpha.shape)}")
-            per_row = main + (1.0 - alpha) * auxiliary
+            auxiliary_weight = 1.0 - alpha.detach()
+            per_row = main + auxiliary_weight * auxiliary
         if memory_per_row is not None:
             per_row = per_row + memory_per_row
         loss = per_row.mean()

--- a/tests/test_training_golden.py
+++ b/tests/test_training_golden.py
@@ -31,7 +31,7 @@ def golden_embeddings() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     return queries, positives, bank
 
 
-def test_golden_vanilla_matches_decoupled_closed_form():
+def test_golden_dcl_ablation_matches_decoupled_closed_form():
     queries, positives, _ = golden_embeddings()
     loss_fn = ContrastiveLoss(
         temperature=0.05,
@@ -65,19 +65,19 @@ def test_golden_atom_gate_uses_query_alpha_for_auxiliary_pressure():
     loss_fn = ContrastiveLoss(
         temperature=0.05,
         learnable_temperature=False,
-        decoupled=True,
+        decoupled=False,
     )
 
     main = loss_fn.info_nce(queries, positives, reduction="none")
     simcse = loss_fn.simcse_term(queries, alternate_queries, reduction="none")
-    actual = (main + (1.0 - alpha) * 0.1 * simcse).mean()
-    expected = torch.mean(main + (1.0 - torch.sigmoid(alpha_logits)) * 0.1 * simcse)
+    actual = (main + (1.0 - alpha.detach()) * 0.1 * simcse).mean()
+    expected = torch.mean(main + (1.0 - torch.sigmoid(alpha_logits).detach()) * 0.1 * simcse)
     torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
 
     actual.backward()
-    assert alpha_logits.grad is not None
-    assert torch.isfinite(alpha_logits.grad).all()
-    assert float(alpha_logits.grad.abs().sum()) > 0.0
+    assert alpha_logits.grad is None
+    assert queries.grad is not None and torch.isfinite(queries.grad).all()
+    assert alternate_queries.grad is not None and torch.isfinite(alternate_queries.grad).all()
 
 
 def test_golden_atomic_adds_weighted_bank_logits_and_live_margin_gradient():
@@ -89,7 +89,7 @@ def test_golden_atomic_adds_weighted_bank_logits_and_live_margin_gradient():
     loss_fn = ContrastiveLoss(
         temperature=0.05,
         learnable_temperature=False,
-        decoupled=True,
+        decoupled=False,
         reduction="none",
     )
 
@@ -111,14 +111,8 @@ def test_golden_atomic_adds_weighted_bank_logits_and_live_margin_gradient():
     bank_cosine = query_norm @ bank_norm.T
     admission = torch.sigmoid((positive_cosine - margin.view(-1, 1) - bank_cosine) / 0.05)
     bank_logits = bank_cosine / 0.05 + log_weights + torch.log(admission.clamp_min(1e-8))
-    negatives = torch.cat(
-        [
-            current.masked_fill(torch.eye(queries.shape[0], dtype=torch.bool), -1e9),
-            bank_logits,
-        ],
-        dim=1,
-    )
-    expected = -current.diagonal() + torch.logsumexp(negatives, dim=-1)
+    logits = torch.cat([current, bank_logits], dim=1)
+    expected = -current.diagonal() + torch.logsumexp(logits, dim=-1)
     torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
 
     actual.mean().backward()

--- a/tests/test_training_job.py
+++ b/tests/test_training_job.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from justatom.training.config import TrainingMethod
+from justatom.training.config import ExperimentRole, TrainingMethod
 from justatom.training.job import RunManifest, TrainingJob, artifact_paths, build_lightning_trainer, write_run_manifest
 from justatom.training.methods import canonical_method_config
 
@@ -40,6 +40,22 @@ def test_atom_gate_manifest_records_detached_auxiliary_control():
     assert manifest.objective_contract == {
         "contrastive_kernel": "coupled_infonce",
         "alpha_aux_gradient": "detached",
+    }
+
+
+def test_dcl_ablation_manifest_records_decoupled_kernel():
+    config = canonical_method_config(TrainingMethod.VANILLA)
+    config = replace(
+        config,
+        experiment=replace(config.experiment, role=ExperimentRole.ABLATION),
+        objective=replace(config.objective, decoupled=True),
+    )
+
+    manifest = RunManifest.from_config(config, git_commit="abc123", git_dirty=False)
+
+    assert manifest.objective_contract == {
+        "contrastive_kernel": "decoupled_infonce",
+        "alpha_aux_gradient": "not_applicable",
     }
 
 

--- a/tests/test_training_job.py
+++ b/tests/test_training_job.py
@@ -22,8 +22,25 @@ def test_manifest_contains_resolved_method_seed_and_git_state(tmp_path: Path):
     assert loaded["experiment"]["seed"] == 42
     assert loaded["git_commit"] == "abc123"
     assert loaded["git_dirty"] is True
+    assert loaded["objective_contract"] == {
+        "contrastive_kernel": "coupled_infonce",
+        "alpha_aux_gradient": "not_applicable",
+    }
     assert loaded["resolved_config"]["memory_bank"]["margin"]["mode"] == "off"
     assert loaded["resolved_config"]["gradient_projection"]["enabled"] is True
+
+
+def test_atom_gate_manifest_records_detached_auxiliary_control():
+    manifest = RunManifest.from_config(
+        canonical_method_config(TrainingMethod.ATOM_GATE),
+        git_commit="abc123",
+        git_dirty=False,
+    )
+
+    assert manifest.objective_contract == {
+        "contrastive_kernel": "coupled_infonce",
+        "alpha_aux_gradient": "detached",
+    }
 
 
 def test_artifact_directories_are_distinct(tmp_path: Path):

--- a/tests/test_training_methods.py
+++ b/tests/test_training_methods.py
@@ -13,6 +13,9 @@ def test_canonical_profiles_have_exact_structural_components():
     gate = canonical_method_config(TrainingMethod.ATOM_GATE)
     atomic = canonical_method_config(TrainingMethod.ATOMIC)
 
+    assert not vanilla.objective.decoupled
+    assert not gate.objective.decoupled
+    assert not atomic.objective.decoupled
     assert not vanilla.alpha_gate.enabled and not vanilla.memory_bank.enabled
     assert gate.alpha_gate.enabled and not gate.memory_bank.enabled
     assert not atomic.alpha_gate.enabled and atomic.memory_bank.enabled
@@ -22,6 +25,18 @@ def test_canonical_profiles_have_exact_structural_components():
     assert atomic.memory_bank.random_negatives == 12
     assert not atomic.memory_bank.adaptive.enabled
     assert atomic.memory_bank.margin.mode is MarginMode.OFF
+
+
+@pytest.mark.parametrize("method", list(TrainingMethod))
+def test_canonical_methods_reject_dcl_but_ablation_allows_it(method):
+    config = canonical_method_config(method)
+    dcl = replace(config, objective=replace(config.objective, decoupled=True))
+
+    with pytest.raises(ValueError, match="coupled InfoNCE.*experiment.role=ablation"):
+        resolve_method(dcl)
+
+    ablation = replace(dcl, experiment=ExperimentConfig(role=ExperimentRole.ABLATION, seed=42))
+    assert resolve_method(ablation).objective.decoupled
 
 
 def test_canonical_atom_gate_rejects_bank():

--- a/tests/test_training_module.py
+++ b/tests/test_training_module.py
@@ -9,7 +9,7 @@ from torch import nn
 from torch.utils.data import DataLoader
 
 from justatom.training.alpha_gate import QueryAlphaGate
-from justatom.training.config import ExperimentConfig, ExperimentRole, MarginMode, TrainingMethod
+from justatom.training.config import ExperimentConfig, ExperimentRole, MarginMode, TrainingMethod, train_config_to_dict
 from justatom.training.methods import canonical_method_config
 from justatom.training.module import ContrastiveTrainingModule
 from justatom.training.objective import ObjectiveOutput
@@ -86,6 +86,34 @@ def test_module_constructs_only_components_required_by_method():
     assert atomic.alpha_gate is None and atomic.memory_bank is not None and atomic.margin_head is None
     assert atomic.config.gradient_projection.enabled
     assert atomic.automatic_optimization is False
+
+
+def test_load_schema_v1_checkpoint_migrates_historical_canonical_dcl_to_ablation(tmp_path):
+    config = canonical_method_config(TrainingMethod.ATOM_GATE)
+    original = ContrastiveTrainingModule.build(TinyEncoder(), config)
+    historical_config = train_config_to_dict(config)
+    historical_config["objective"]["decoupled"] = True
+    checkpoint = tmp_path / "historical-checkpoint.pt"
+    torch.save(
+        {
+            "schema_version": 1,
+            "resolved_config": historical_config,
+            "state_dict": original.state_dict(),
+            "optimizer_states": [],
+            "epoch": 0,
+            "global_step": 1,
+        },
+        checkpoint,
+    )
+
+    restored, optimizer_states = ContrastiveTrainingModule.load_research_checkpoint(
+        checkpoint,
+        encoder=TinyEncoder(),
+    )
+
+    assert restored.config.experiment.role is ExperimentRole.ABLATION
+    assert restored.config.objective.decoupled
+    assert optimizer_states == []
 
 
 def test_vanilla_bank_ablation_constructs_bank_without_gate_or_margin_head():

--- a/tests/test_training_module.py
+++ b/tests/test_training_module.py
@@ -151,6 +151,19 @@ def test_alpha_mix_weight_uses_exact_linear_warmup():
     assert module.effective_alpha_mix_weight(20) == pytest.approx(0.3)
 
 
+def test_atom_gate_reports_effective_detached_auxiliary_weight():
+    module = ContrastiveTrainingModule.build(
+        TinyEncoder(),
+        canonical_method_config(TrainingMethod.ATOM_GATE),
+    )
+
+    output = module.compute_training_step(tiny_batch(), step=0)
+
+    assert output.metrics["alpha_aux_weight/mean"] == pytest.approx(1.0 - output.metrics["alpha/mean"])
+    assert output.metrics["alpha_aux_weight/min"] == pytest.approx(1.0 - output.metrics["alpha/max"])
+    assert output.metrics["alpha_aux_weight/max"] == pytest.approx(1.0 - output.metrics["alpha/min"])
+
+
 def test_compute_training_step_rejects_nonfinite_loss(monkeypatch):
     module = ContrastiveTrainingModule.build(TinyEncoder(), canonical_method_config(TrainingMethod.VANILLA))
     bad_output = ObjectiveOutput(

--- a/tests/test_training_objective.py
+++ b/tests/test_training_objective.py
@@ -107,6 +107,32 @@ def test_objective_atom_gate_keeps_alpha_live_for_pair_supervision():
     assert float(alpha.grad.abs().sum()) > 0.0
 
 
+def test_objective_atom_gate_keeps_alpha_live_for_entropy_regularization():
+    objective = ContrastiveObjective(
+        ObjectiveConfig(
+            temperature=1.0,
+            learnable_temperature=False,
+            decoupled=False,
+        )
+    )
+    embeddings = F.normalize(torch.eye(2, 4), dim=-1)
+    alpha = torch.tensor([0.2, 0.7], requires_grad=True)
+
+    output = objective(
+        ObjectiveInputs(
+            queries=embeddings,
+            positives=embeddings,
+            alpha=alpha,
+            alpha_entropy_weight=0.1,
+        )
+    )
+    output.loss.backward()
+
+    assert alpha.grad is not None
+    assert torch.isfinite(alpha.grad).all()
+    assert float(alpha.grad.abs().sum()) > 0.0
+
+
 def test_objective_regularizes_raw_margin_to_constant_base():
     config = MarginConfig(
         mode=MarginMode.QUERY,

--- a/tests/test_training_objective.py
+++ b/tests/test_training_objective.py
@@ -23,12 +23,13 @@ def test_objective_vanilla_has_no_auxiliary_components():
     assert output.metrics["loss/memory_margin_regularization"] == 0.0
 
 
-def test_objective_atom_gate_uses_augment_formula():
+def test_objective_atom_gate_detaches_alpha_only_from_auxiliary_gradient():
     torch.manual_seed(1)
     objective = ContrastiveObjective(
         ObjectiveConfig(
             temperature=1.0,
             learnable_temperature=False,
+            decoupled=False,
             simcse_dropout_weight=0.1,
         )
     )
@@ -47,10 +48,63 @@ def test_objective_atom_gate_uses_augment_formula():
     )
 
     assert output.simcse_per_row is not None
-    expected = (output.main_per_row + (1.0 - alpha) * 0.1 * output.simcse_per_row).mean()
+    expected = (output.main_per_row + (1.0 - alpha.detach()) * 0.1 * output.simcse_per_row).mean()
     torch.testing.assert_close(output.loss, expected)
+
+    high_alpha = objective(
+        ObjectiveInputs(
+            queries=queries,
+            positives=positives,
+            query_alt=alternate_queries,
+            alpha=torch.full_like(alpha, 0.8),
+        )
+    )
+    low_alpha = objective(
+        ObjectiveInputs(
+            queries=queries,
+            positives=positives,
+            query_alt=alternate_queries,
+            alpha=torch.full_like(alpha, 0.2),
+        )
+    )
+    assert low_alpha.loss.detach() > high_alpha.loss.detach()
+
+    auxiliary_only = output.loss - output.main_per_row.mean()
+    auxiliary_only.backward()
+    assert alpha.grad is None
+    assert queries.grad is not None and float(queries.grad.abs().sum()) > 0.0
+    assert alternate_queries.grad is not None and float(alternate_queries.grad.abs().sum()) > 0.0
+
+
+def test_objective_atom_gate_keeps_alpha_live_for_pair_supervision():
+    objective = ContrastiveObjective(
+        ObjectiveConfig(
+            temperature=1.0,
+            learnable_temperature=False,
+            decoupled=False,
+        )
+    )
+    queries = F.normalize(torch.eye(2, 4), dim=-1)
+    positives = queries.clone()
+    alpha = torch.tensor([0.4, 0.6], requires_grad=True)
+    semantic = torch.tensor([[0.9, 0.1], [0.2, 0.8]])
+    lexical = torch.tensor([[0.1, 0.8], [0.9, 0.2]])
+
+    output = objective(
+        ObjectiveInputs(
+            queries=queries,
+            positives=positives,
+            alpha=alpha,
+            semantic_pair_scores=semantic,
+            lexical_pair_scores=lexical,
+            alpha_mix_weight=0.3,
+        )
+    )
     output.loss.backward()
-    assert alpha.grad is not None and float(alpha.grad.abs().sum()) > 0.0
+
+    assert alpha.grad is not None
+    assert torch.isfinite(alpha.grad).all()
+    assert float(alpha.grad.abs().sum()) > 0.0
 
 
 def test_objective_regularizes_raw_margin_to_constant_base():


### PR DESCRIPTION
## Summary

- align `vanilla`, `atom_gate`, and `atomic` on standard coupled InfoNCE for canonical comparisons
- prevent the SimCSE auxiliary path from optimizing `alpha(q)` toward the loss-disabling solution
- keep `alpha(q)` live for semantic/lexical pair supervision and optional entropy regularization
- record the contrastive kernel and alpha-gradient policy in run manifests and telemetry
- preserve schema-v1 DCL checkpoints by loading them as historical ablations

## Objective

Before this change, `atom_gate` used:

```text
L = L_main + (1 - alpha) * lambda_aux * L_simcse + lambda_mix * L_mix(alpha)
```

Because `L_simcse >= 0` for coupled cross-entropy, its direct gradient rewards increasing `alpha` until the auxiliary term is disabled. The new objective uses:

```text
L = L_main
  + (1 - stop_gradient(alpha)) * lambda_aux * L_simcse
  + lambda_mix * L_mix(alpha)
  - lambda_entropy * H(alpha)
```

The encoder still receives query-conditioned SimCSE pressure. The alpha head is trained by retrieval evidence instead of by an incentive to turn that pressure off.

## Canonical methods

| Method | Shared primary loss | Additional mechanism |
|---|---|---|
| `vanilla` | coupled InfoNCE | none |
| `atom_gate` | coupled InfoNCE | detached alpha-controlled SimCSE plus semantic/lexical mixing |
| `atomic` | coupled InfoNCE | FIFO memory negatives with projected memory gradients |

DCL remains available under `experiment.role: ablation`; canonical DCL overrides fail before model loading.

## Reproducibility

- `alpha_aux_weight/*` records the effective `1 - alpha` distribution.
- `run_manifest.yaml` records `objective_contract.contrastive_kernel` and `objective_contract.alpha_aux_gradient`.
- Historical schema-v1 canonical DCL checkpoints load without changing their weights or objective and are relabeled as ablations.
- Results from the old canonical objective must not be pooled with new runs. Matched benchmarks must be rerun.

## Verification

- TDD red/green coverage for auxiliary and pair-supervision gradients
- schema-v1 checkpoint migration regression
- corrected coupled/detached golden contracts
- `577 passed`: `pytest -q tests`
- Black and isort checks pass for all 178 tracked Python files
- pylint passes with the repository CI flags
- mypy passes for all 11 CI training modules
- `mkdocs build --strict` passes
- independent code review: no Critical, Important, or Minor findings after fixes
